### PR TITLE
Boost table view perf

### DIFF
--- a/.changeset/many-flowers-call.md
+++ b/.changeset/many-flowers-call.md
@@ -1,0 +1,5 @@
+---
+"@tablex/core": minor
+---
+
+Added pagination and used Tanstack Virtual for table view

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,6 +5,7 @@ public
 src-tauri
 pnpm-lock.yaml
 /**/dist
-/apps/web/src/components
+apps/core/src/components
+apps/web/src/components
 apps/web-astro/src/components
 .all-contributorsrc

--- a/apps/core/.eslintrc.json
+++ b/apps/core/.eslintrc.json
@@ -8,11 +8,11 @@
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": [
-    "/**/out",
-    "/node_modules",
-    "/apps/**/node_modules",
-    "/apps/**/.next",
-    "/apps/core/src-tauri/target"
+    "out",
+    "node_modules",
+    ".next",
+    "src-tauri/target",
+    "src/components/ui"
   ],
   "settings": {
     "next": {

--- a/apps/core/package.json
+++ b/apps/core/package.json
@@ -25,14 +25,15 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^5.8.4",
     "@tanstack/react-table": "^8.10.7",
+    "@tanstack/react-virtual": "^3.1.2",
     "@tauri-apps/api": "^1.5.1",
     "cmdk": "^0.2.0",
+    "geist": "^1.2.0",
     "next": "14.0.2",
     "next-themes": "^0.2.1",
     "react-hook-form": "^7.48.2",
     "react-hot-toast": "^2.4.1",
-    "zod": "^3.22.4",
-    "geist": "^1.2.0"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^1.5.6",

--- a/apps/core/src-tauri/src/drivers/mysql/row.rs
+++ b/apps/core/src-tauri/src/drivers/mysql/row.rs
@@ -1,23 +1,32 @@
 use crate::{drivers::mysql::decode, DbInstance};
-use serde_json::value::Value as JsonValue;
+use serde_json::value::{Map as JsonMap, Value as JsonValue};
 use sqlx::{Column, Row};
-use std::collections::HashMap;
 use tauri::State;
 
-pub async fn get_rows(
+pub async fn get_paginated_rows(
     db: &State<'_, DbInstance>,
     table_name: String,
-) -> Result<Vec<HashMap<String, JsonValue>>, String> {
+    page_index: u16,
+    page_size: u32,
+) -> Result<JsonMap<String, JsonValue>, String> {
     let long_lived = db.mysql_pool.lock().await;
     let conn = long_lived.as_ref().unwrap();
 
-    let rows = sqlx::query(format!("SELECT * FROM {};", table_name).as_str())
-        .fetch_all(conn)
-        .await
-        .unwrap();
+    let rows = sqlx::query(
+        format!(
+            "SELECT * FROM {} limit {} offset {};",
+            table_name,
+            page_size,
+            page_index as u32 * page_size
+        )
+        .as_str(),
+    )
+    .fetch_all(conn)
+    .await
+    .unwrap();
     let mut values = Vec::new();
     for row in rows {
-        let mut value = HashMap::default();
+        let mut value = JsonMap::default();
         for (i, column) in row.columns().iter().enumerate() {
             let v = row.try_get_raw(i).unwrap();
 
@@ -28,7 +37,17 @@ pub async fn get_rows(
 
         values.push(value);
     }
-    Ok(values)
+    let page_count_result = sqlx::query(format!("SELECT COUNT(*) from {}", table_name).as_str())
+        .fetch_one(conn)
+        .await
+        .unwrap();
+    let page_count = page_count_result.try_get::<u32, usize>(0).unwrap() / page_size;
+
+    let mut result = JsonMap::new();
+    result.insert("data".to_string(), values.into());
+    result.insert("pageCount".to_string(), page_count.into());
+
+    Ok(result)
 }
 
 pub async fn delete_rows(

--- a/apps/core/src-tauri/src/drivers/sqlite/row.rs
+++ b/apps/core/src-tauri/src/drivers/sqlite/row.rs
@@ -1,23 +1,32 @@
 use crate::{drivers::sqlite::decode, DbInstance};
-use serde_json::value::Value as JsonValue;
+use serde_json::value::{Map as JsonMap, Value as JsonValue};
 use sqlx::{Column, Row};
-use std::collections::HashMap;
 use tauri::State;
 
-pub async fn get_rows(
+pub async fn get_paginated_rows(
     db: &State<'_, DbInstance>,
     table_name: String,
-) -> Result<Vec<HashMap<String, JsonValue>>, String> {
+    page_index: u16,
+    page_size: u32,
+) -> Result<JsonMap<String, JsonValue>, String> {
     let long_lived = db.sqlite_pool.lock().await;
     let conn = long_lived.as_ref().unwrap();
 
-    let rows = sqlx::query(format!("SELECT * FROM {};", table_name).as_str())
-        .fetch_all(conn)
-        .await
-        .unwrap();
+    let rows = sqlx::query(
+        format!(
+            "SELECT * FROM {} limit {} offset {};",
+            table_name,
+            page_size,
+            page_index as u32 * page_size
+        )
+        .as_str(),
+    )
+    .fetch_all(conn)
+    .await
+    .unwrap();
     let mut values = Vec::new();
     for row in rows {
-        let mut value = HashMap::default();
+        let mut value = JsonMap::default();
         for (i, column) in row.columns().iter().enumerate() {
             let v = row.try_get_raw(i).unwrap();
 
@@ -28,7 +37,17 @@ pub async fn get_rows(
 
         values.push(value);
     }
-    Ok(values)
+    let page_count_result = sqlx::query(format!("SELECT COUNT(*) from {}", table_name).as_str())
+        .fetch_one(conn)
+        .await
+        .unwrap();
+    let page_count = page_count_result.try_get::<u32, usize>(0).unwrap() / page_size;
+
+    let mut result = JsonMap::new();
+    result.insert("data".to_string(), values.into());
+    result.insert("pageCount".to_string(), page_count.into());
+
+    Ok(result)
 }
 
 pub async fn delete_rows(

--- a/apps/core/src-tauri/src/main.rs
+++ b/apps/core/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ use connection::{
     connections_exist, create_connection_record, delete_connection_record, establish_connection,
     get_connection_details, get_connections, test_connection,
 };
-use row::{create_row, delete_rows, get_rows, update_row};
+use row::{create_row, delete_rows, get_paginated_rows, update_row};
 use sqlx::sqlite::SqlitePool;
 use sqlx::{MySqlPool, PgPool};
 use table::{get_columns_definition, get_tables};
@@ -89,7 +89,7 @@ fn main() {
             get_connections,
             get_connection_details,
             get_tables,
-            get_rows,
+            get_paginated_rows,
             delete_rows,
             get_columns_definition,
             create_row,

--- a/apps/core/src-tauri/src/row.rs
+++ b/apps/core/src-tauri/src/row.rs
@@ -11,16 +11,24 @@ use std::result::Result::Ok;
 use tauri::State;
 
 #[tauri::command]
-pub async fn get_rows(
+pub async fn get_paginated_rows(
     db: State<'_, DbInstance>,
     table_name: String,
-) -> Result<Vec<HashMap<String, JsonValue>>, String> {
+    page_index: u16,
+    page_size: u32,
+) -> Result<Map<String, JsonValue>, String> {
     let long_lived = db.driver.lock().await;
     let driver = long_lived.as_ref().unwrap();
     match driver {
-        Drivers::SQLite => sqlite::row::get_rows(&db, table_name).await,
-        Drivers::PostgreSQL => postgres::row::get_rows(&db, table_name).await,
-        Drivers::MySQL => mysql::row::get_rows(&db, table_name).await,
+        Drivers::SQLite => {
+            sqlite::row::get_paginated_rows(&db, table_name, page_index, page_size).await
+        }
+        Drivers::PostgreSQL => {
+            postgres::row::get_paginated_rows(&db, table_name, page_index, page_size).await
+        }
+        Drivers::MySQL => {
+            mysql::row::get_paginated_rows(&db, table_name, page_index, page_size).await
+        }
     }
 }
 

--- a/apps/core/src-tauri/src/utils.rs
+++ b/apps/core/src-tauri/src/utils.rs
@@ -98,14 +98,14 @@ pub fn read_from_connections_file(
 ) -> Result<serde_json::Value, String> {
     let prefix = connections_file_path.parent().unwrap();
     std::fs::create_dir_all(prefix)
-        .or_else(|_| Err("Couldn't create config directory for TableX".to_string()))?;
+        .map_err(|_| "Couldn't create config directory for TableX".to_string())?;
 
     let mut file = OpenOptions::new()
         .read(true)
         .create(true)
         .write(true)
         .open(connections_file_path)
-        .or_else(|_| Err("connections.json file is not found"))?;
+        .map_err(|_| "connections.json file is not found")?;
 
     if file.metadata().unwrap().len() == 0 {
         write!(file, "{{}}")

--- a/apps/core/src/app/dashboard/details/_components/data-table.tsx
+++ b/apps/core/src/app/dashboard/details/_components/data-table.tsx
@@ -35,7 +35,12 @@ import {
 import { Sheet } from "@/components/ui/sheet"
 import { useQueryClient, type QueryClient } from "@tanstack/react-query"
 import { unregister } from "@tauri-apps/api/globalShortcut"
-import { ChevronLeft, ChevronRight } from "lucide-react"
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight
+} from "lucide-react"
 import { useLayoutEffect, type Dispatch, type SetStateAction } from "react"
 import {
   copyRowIntoClipboard,
@@ -221,6 +226,16 @@ const PaginationControls = ({ table }: PaginationControlsProps) => {
           <Button
             variant={"ghost"}
             size={"sm"}
+            onClick={() => table.setPageIndex(0)}
+            disabled={!table.getCanPreviousPage()}
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+        </PaginationItem>
+        <PaginationItem>
+          <Button
+            variant={"ghost"}
+            size={"sm"}
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
           >
@@ -242,6 +257,16 @@ const PaginationControls = ({ table }: PaginationControlsProps) => {
           >
             Next
             <ChevronRight className="ml-1 h-4 w-4 p-0" />
+          </Button>
+        </PaginationItem>
+        <PaginationItem>
+          <Button
+            variant={"ghost"}
+            size={"sm"}
+            onClick={() => table.setPageIndex(table.getPageCount() - 1)}
+            disabled={!table.getCanNextPage()}
+          >
+            <ChevronsRight className="h-4 w-4" />
           </Button>
         </PaginationItem>
       </PaginationContent>

--- a/apps/core/src/app/dashboard/details/actions.ts
+++ b/apps/core/src/app/dashboard/details/actions.ts
@@ -1,3 +1,4 @@
+import { PaginatedRows } from "@/lib/types"
 import { customToast } from "@/lib/utils"
 import { type QueryClient } from "@tanstack/react-query"
 import type { Row, Table } from "@tanstack/react-table"
@@ -7,8 +8,16 @@ import { invoke } from "@tauri-apps/api/tauri"
 import type { Dispatch, SetStateAction } from "react"
 import toast from "react-hot-toast"
 
-export const getRows = async (tableName: string) => {
-  const result = await invoke<Record<string, any>[]>("get_rows", { tableName })
+export const getPaginatedRows = async (
+  tableName: string,
+  pageIndex: number,
+  pageSize: number
+) => {
+  const result = await invoke<PaginatedRows>("get_paginated_rows", {
+    tableName,
+    pageIndex,
+    pageSize
+  })
   return result
 }
 

--- a/apps/core/src/app/dashboard/details/hooks.ts
+++ b/apps/core/src/app/dashboard/details/hooks.ts
@@ -65,7 +65,7 @@ export const useSetupReactTable = <TData, TValue>({
 const useSetupPagination = () => {
   const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
     pageIndex: 0,
-    pageSize: 10 // TODO: hard coded for now
+    pageSize: 500 // TODO: hard coded for now
   })
   const defaultData = useMemo(() => [], [])
   const pagination = useMemo(

--- a/apps/core/src/app/dashboard/details/hooks.ts
+++ b/apps/core/src/app/dashboard/details/hooks.ts
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query"
+import {
+  getCoreRowModel,
+  getSortedRowModel,
+  useReactTable,
+  type ColumnDef,
+  type PaginationState,
+  type Row,
+  type SortingState
+} from "@tanstack/react-table"
+import { useMemo, useRef, useState } from "react"
+import { getPaginatedRows } from "./actions"
+
+type SetupReactTableOptions<TData, TValue> = {
+  columns: ColumnDef<TData, TValue>[]
+  tableName: string
+}
+
+export const useSetupReactTable = <TData, TValue>({
+  tableName,
+  columns
+}: SetupReactTableOptions<TData, TValue>) => {
+  const { defaultData, pagination, setPagination, pageIndex, pageSize } =
+    useSetupPagination()
+
+  const { data: rows, isLoading: isRowsLoading } = useQuery({
+    queryKey: ["table_rows", tableName, { pageIndex, pageSize }],
+    queryFn: async () => await getPaginatedRows(tableName, pageIndex, pageSize)
+  })
+
+  const [isSheetOpen, setIsSheetOpen] = useState(false)
+  const [contextMenuRow, setContextMenuRow] = useState<Row<any>>()
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [rowSelection, setRowSelection] = useState({})
+  const tableRef = useRef<HTMLTableElement>(null)
+  const table = useReactTable({
+    data: (rows?.data as TData[]) ?? defaultData,
+    columns,
+    pageCount: rows?.pageCount ?? -1,
+    getCoreRowModel: getCoreRowModel(),
+    onSortingChange: setSorting,
+    getSortedRowModel: getSortedRowModel(),
+    onRowSelectionChange: setRowSelection,
+    onPaginationChange: setPagination,
+    state: {
+      sorting,
+      rowSelection,
+      pagination
+    },
+    manualPagination: true,
+    debugTable: process.env.NODE_ENV === "development" ? true : false
+  })
+
+  return {
+    isRowsLoading,
+    isSheetOpen,
+    setIsSheetOpen,
+    contextMenuRow,
+    setContextMenuRow,
+    tableRef,
+    table
+  }
+}
+
+const useSetupPagination = () => {
+  const [{ pageIndex, pageSize }, setPagination] = useState<PaginationState>({
+    pageIndex: 0,
+    pageSize: 10 // TODO: hard coded for now
+  })
+  const defaultData = useMemo(() => [], [])
+  const pagination = useMemo(
+    () => ({
+      pageIndex,
+      pageSize
+    }),
+    [pageIndex, pageSize]
+  )
+  return { defaultData, pagination, setPagination, pageIndex, pageSize }
+}

--- a/apps/core/src/app/dashboard/details/page.tsx
+++ b/apps/core/src/app/dashboard/details/page.tsx
@@ -2,29 +2,22 @@
 import LoadingSpinner from "@/components/loading-spinner"
 import { useQuery } from "@tanstack/react-query"
 import { useSearchParams } from "next/navigation"
-import { useRef } from "react"
 import { generateColumnsDefs } from "./_components/columns"
 import DataTable from "./_components/data-table"
 
 const TableDataPage = () => {
   const tableName = useSearchParams().get("tableName")!
-  const sectionRef = useRef<HTMLDivElement>(null)
 
   const { data: columns, isLoading: isColumnsLoading } = useQuery({
     queryKey: ["table_columns", tableName],
     queryFn: async () => await generateColumnsDefs(tableName)
   })
 
+  if (isColumnsLoading) return <LoadingSpinner />
+
   return (
-    <section
-      className="flex w-full flex-col overflow-auto will-change-scroll"
-      ref={sectionRef}
-    >
-      {isColumnsLoading ? (
-        <LoadingSpinner />
-      ) : (
-        <DataTable columns={columns!} tableName={tableName} />
-      )}
+    <section className="flex w-full flex-col overflow-auto will-change-scroll">
+      <DataTable columns={columns!} tableName={tableName} />
     </section>
   )
 }

--- a/apps/core/src/app/dashboard/details/page.tsx
+++ b/apps/core/src/app/dashboard/details/page.tsx
@@ -1,41 +1,30 @@
 "use client"
 import LoadingSpinner from "@/components/loading-spinner"
-import { useQueries } from "@tanstack/react-query"
+import { useQuery } from "@tanstack/react-query"
 import { useSearchParams } from "next/navigation"
 import { useRef } from "react"
 import { generateColumnsDefs } from "./_components/columns"
 import DataTable from "./_components/data-table"
-import { getRows } from "./actions"
 
 const TableDataPage = () => {
   const tableName = useSearchParams().get("tableName")!
   const sectionRef = useRef<HTMLDivElement>(null)
 
-  const {
-    "0": { data: columns, isLoading: isColumnsLoading },
-    "1": { data: rows, isLoading: isRowsLoading }
-  } = useQueries({
-    queries: [
-      {
-        queryKey: ["table_columns", tableName],
-        queryFn: async () => await generateColumnsDefs(tableName)
-      },
-      {
-        queryKey: ["table_rows", tableName],
-        queryFn: async () => await getRows(tableName)
-      }
-    ]
+  const { data: columns, isLoading: isColumnsLoading } = useQuery({
+    queryKey: ["table_columns", tableName],
+    queryFn: async () => await generateColumnsDefs(tableName)
   })
-
-  if (isColumnsLoading || isRowsLoading) return <LoadingSpinner />
 
   return (
     <section
       className="flex w-full flex-col overflow-auto will-change-scroll"
       ref={sectionRef}
     >
-      <h1 className="w-full p-4 text-2xl font-bold ">{tableName}</h1>
-      <DataTable columns={columns!} data={rows!} />
+      {isColumnsLoading ? (
+        <LoadingSpinner />
+      ) : (
+        <DataTable columns={columns!} tableName={tableName} />
+      )}
     </section>
   )
 }

--- a/apps/core/src/components/ui/pagination.tsx
+++ b/apps/core/src/components/ui/pagination.tsx
@@ -1,0 +1,117 @@
+import * as React from "react"
+import { ChevronLeft, ChevronRight, MoreHorizontal } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { ButtonProps, buttonVariants } from "@/components/ui/button"
+
+const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
+  <nav
+    role="navigation"
+    aria-label="pagination"
+    className={cn("mx-auto flex w-full justify-center", className)}
+    {...props}
+  />
+)
+Pagination.displayName = "Pagination"
+
+const PaginationContent = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<"ul">
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    className={cn("flex flex-row items-center gap-1", className)}
+    {...props}
+  />
+))
+PaginationContent.displayName = "PaginationContent"
+
+const PaginationItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<"li">
+>(({ className, ...props }, ref) => (
+  <li ref={ref} className={cn("", className)} {...props} />
+))
+PaginationItem.displayName = "PaginationItem"
+
+type PaginationLinkProps = {
+  isActive?: boolean
+} & Pick<ButtonProps, "size"> &
+  React.ComponentProps<"a">
+
+const PaginationLink = ({
+  className,
+  isActive,
+  size = "icon",
+  ...props
+}: PaginationLinkProps) => (
+  <a
+    aria-current={isActive ? "page" : undefined}
+    className={cn(
+      buttonVariants({
+        variant: isActive ? "outline" : "ghost",
+        size,
+      }),
+      className
+    )}
+    {...props}
+  />
+)
+PaginationLink.displayName = "PaginationLink"
+
+const PaginationPrevious = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to previous page"
+    size="default"
+    className={cn("gap-1 pl-2.5", className)}
+    {...props}
+  >
+    <ChevronLeft className="h-4 w-4" />
+    <span>Previous</span>
+  </PaginationLink>
+)
+PaginationPrevious.displayName = "PaginationPrevious"
+
+const PaginationNext = ({
+  className,
+  ...props
+}: React.ComponentProps<typeof PaginationLink>) => (
+  <PaginationLink
+    aria-label="Go to next page"
+    size="default"
+    className={cn("gap-1 pr-2.5", className)}
+    {...props}
+  >
+    <span>Next</span>
+    <ChevronRight className="h-4 w-4" />
+  </PaginationLink>
+)
+PaginationNext.displayName = "PaginationNext"
+
+const PaginationEllipsis = ({
+  className,
+  ...props
+}: React.ComponentProps<"span">) => (
+  <span
+    aria-hidden
+    className={cn("flex h-9 w-9 items-center justify-center", className)}
+    {...props}
+  >
+    <MoreHorizontal className="h-4 w-4" />
+    <span className="sr-only">More pages</span>
+  </span>
+)
+PaginationEllipsis.displayName = "PaginationEllipsis"
+
+export {
+  Pagination,
+  PaginationContent,
+  PaginationEllipsis,
+  PaginationItem,
+  PaginationLink,
+  PaginationNext,
+  PaginationPrevious,
+}

--- a/apps/core/src/components/ui/table.tsx
+++ b/apps/core/src/components/ui/table.tsx
@@ -1,17 +1,25 @@
 import * as React from "react"
 
 import { cn } from "@/lib/utils"
+import { Virtualizer } from "@tanstack/react-virtual"
+
+interface TableProps extends   React.HTMLAttributes<HTMLTableElement>   {
+  virtualizerRef:React.RefObject<HTMLDivElement>
+  virtualizer:Virtualizer<any,any>
+}
 
 const Table = React.forwardRef<
   HTMLTableElement,
-  React.HTMLAttributes<HTMLTableElement>
->(({ className, ...props }, ref) => (
-  <div className="relative h-full w-full overflow-auto">
+  TableProps
+>(({ className,virtualizerRef,virtualizer, ...props }, ref) => (
+  <div className="relative h-full w-full overflow-auto" >
+    <div ref={virtualizerRef} style={{height:`${virtualizer.getTotalSize()}px`}}>
     <table
       ref={ref}
       className={cn("w-full caption-bottom text-sm", className)}
       {...props}
     />
+    </div>
   </div>
 ))
 Table.displayName = "Table"
@@ -112,3 +120,4 @@ export {
   TableHeader,
   TableRow
 }
+

--- a/apps/core/src/lib/types.ts
+++ b/apps/core/src/lib/types.ts
@@ -31,3 +31,8 @@ export interface ColumnProps {
   defaultValue?: any
   isPK: boolean
 }
+
+export interface PaginatedRows {
+  data: Record<string, any>[]
+  pageCount: number
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       '@tanstack/react-table':
         specifier: ^8.10.7
         version: 8.11.2(react-dom@18.2.0)(react@18.2.0)
+      '@tanstack/react-virtual':
+        specifier: ^3.1.2
+        version: 3.1.2(react-dom@18.2.0)(react@18.2.0)
       '@tauri-apps/api':
         specifier: ^1.5.1
         version: 1.5.3
@@ -3274,9 +3277,24 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
+  /@tanstack/react-virtual@3.1.2(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-qibmxtctgOZo2I+3Rw5GR9kXgaa15U5r3/idDY1ItUKW15UK7GhCfyIfE6qYuJ1fxQF6dJDsD8SbpPyuJgpxuA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@tanstack/virtual-core': 3.1.2
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: false
+
   /@tanstack/table-core@8.11.2:
     resolution: {integrity: sha512-rR0VEQOtr0ARLvaNLaSQnt2BVwOp0OavOUA0LcZ3N45tLYXc4sXruNv8kJ7R7+5W1CrzGha217tzjBG83CpoMQ==}
     engines: {node: '>=12'}
+    dev: false
+
+  /@tanstack/virtual-core@3.1.2:
+    resolution: {integrity: sha512-DATZJs8iejkIUqXZe6ruDAnjFo78BKnIIgqQZrc7CmEFqfLEN/TPD91n4hRfo6hpRB6xC00bwKxv7vdjFNEmOg==}
     dev: false
 
   /@tauri-apps/api@1.5.3:


### PR DESCRIPTION
closes #33 

## Features
- Backend
  - return paginated rows with `data` and `pageCount` fields
   The page size is hard coded for now to `500`
- Frontend
  - Used Tanstack Table pagination feature for functionality 
  - Used shadcn/ui `Pagination` component for controls
  - Used Tanstack Virtual to virtualize the table view