### PR TITLE
feat(cli): support trivial cli args like --version

### DIFF
--- a/.changeset/warm-ladybugs-exist.md
+++ b/.changeset/warm-ladybugs-exist.md
@@ -1,0 +1,5 @@
+---
+"@tablex/core": patch
+---
+
+Support trivial cli args like --version

--- a/apps/core/src-tauri/Cargo.lock
+++ b/apps/core/src-tauri/Cargo.lock
@@ -76,6 +76,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d96bd03f33fe50a863e394ee9718a706f988b9079b20c3784fb726e7678b62fb"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8901269c6307e8d93993578286ac0edf7f195079ffff5ebdeea6a59ffb7e36bc"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ac65da39e5fe5ab759307499ddad880d724eed2f6ce5b5e8a26f4f387928c"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28923312444cdd728e4738b3f9c9cac739500909bb3d3c94b43551b16517648"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cd54b81ec8d6180e24654d0b371ad22fc3dd083b6ff8ba325b72e00c87660a7"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,6 +414,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c918d541ef2913577a0f9566e9ce27cb35b6df072075769e0b26cb5a554520da"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3e7391dad68afb0c2ede1bf619f579a3dc9c2ec67f089baa397123a2f3d1eb"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim 0.11.0",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "307bc0538d5f0f83b8248db3087aa92fe504e4691294d0c96c0eabc33f47ba47"
+dependencies = [
+ "heck 0.4.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.48",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+
+[[package]]
 name = "clipboard-win"
 version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +499,12 @@ name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "combine"
@@ -617,7 +711,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
+ "strsim 0.10.0",
  "syn 2.0.48",
 ]
 
@@ -3352,6 +3446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "strsim"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee073c9e4cd00e28217186dbe12796d692868f432bf2e97ee73bed0c56dfa01"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3422,6 +3522,7 @@ dependencies = [
 name = "table_x"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "regex",
  "serde",
  "serde_json",
@@ -4065,6 +4166,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "uuid"

--- a/apps/core/src-tauri/Cargo.toml
+++ b/apps/core/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ strip = true
 tauri-build = { version = "1.5.0", features = [] }
 
 [dependencies]
+clap = { version = "4.5.1", features = ["derive"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tauri = { version = "1.5.2", features = [ "shell-open", "os-all", "clipboard-write-text", "global-shortcut-all", "dialog-open", "test", "process-command-api"] }

--- a/apps/core/src-tauri/src/main.rs
+++ b/apps/core/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ mod row;
 mod table;
 mod utils;
 
+use clap::Parser;
 use connection::{
     connections_exist, create_connection_record, delete_connection_record, establish_connection,
     get_connection_details, get_connections, test_connection,
@@ -20,6 +21,10 @@ use tauri::api::process::CommandChild;
 use tauri::{Manager, WindowEvent};
 use tokio::sync::Mutex;
 use utils::Drivers;
+
+#[derive(Parser, Debug)]
+#[command(version, about)]
+struct Args {}
 
 #[derive(Default)]
 pub struct DbInstance {
@@ -62,6 +67,10 @@ impl DbInstance {
 }
 
 fn main() {
+    // Process basic cli args (like --help and --version).
+    // TODO: #46 - Support arguments such as DB connection.
+    Args::parse();
+
     tauri::Builder::default()
         .manage(DbInstance {
             sqlite_pool: Default::default(),


### PR DESCRIPTION
Fixes #42.

The advantages are that if you pass standard arguments like `--version` it will interpret those normally, and if you pass totally invalid args like `--pod-bay-doors=open` it will tell you they're unrecognized instead of seeming to accept them and launching normally.

The secret was to ignore Tauri's brittle cli config integration and just use clap directly. I asked how to get Tauri's hooks to behave normally (https://discord.com/channels/616186924390023171/1212281820302016552) but didn't get an answer, and anyway don't see any advantage to trying to use Tauri's helpers vs. using clap directly.