### PR TITLE
feat: Universal error interface ✨🎨

### DIFF
--- a/.changeset/cyan-lobsters-float.md
+++ b/.changeset/cyan-lobsters-float.md
@@ -1,0 +1,5 @@
+---
+"@tablex/core": patch
+---
+
+Creates a universal error interface integrated with frontend toast notifications.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
 dependencies = [
  "clipboard-win",
- "core-graphics",
+ "core-graphics 0.23.2",
  "image 0.25.2",
  "log",
  "objc2",
@@ -453,9 +453,9 @@ dependencies = [
 
 [[package]]
 name = "brotli"
-version = "3.5.0"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+checksum = "74f7971dbd9326d58187408ab83117d8ac1bb9c17b085fdacd1cf2f598719b6b"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -464,9 +464,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "2.5.1"
+version = "4.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -689,9 +689,25 @@ checksum = "f6140449f97a6e97f9511815c5632d84c8aacf8ac271ad77c559218161a1373c"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "cocoa-foundation",
- "core-foundation",
- "core-graphics",
+ "cocoa-foundation 0.1.2",
+ "core-foundation 0.9.4",
+ "core-graphics 0.23.2",
+ "foreign-types 0.5.0",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f79398230a6e2c08f5c9760610eb6924b52aa9e7950a619602baba59dcbbdbb2"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "cocoa-foundation 0.2.0",
+ "core-foundation 0.10.0",
+ "core-graphics 0.24.0",
  "foreign-types 0.5.0",
  "libc",
  "objc",
@@ -705,8 +721,22 @@ checksum = "8c6234cbb2e4c785b456c0644748b1ac416dd045799740356f8363dfe00c93f7"
 dependencies = [
  "bitflags 1.3.2",
  "block",
- "core-foundation",
- "core-graphics-types",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "libc",
+ "objc",
+]
+
+[[package]]
+name = "cocoa-foundation"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e14045fb83be07b5acf1c0884b2180461635b433455fa35d1cd6f17f1450679d"
+dependencies = [
+ "bitflags 2.6.0",
+ "block",
+ "core-foundation 0.10.0",
+ "core-graphics-types 0.2.0",
  "libc",
  "objc",
 ]
@@ -765,10 +795,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "core-foundation-sys"
-version = "0.8.6"
+name = "core-foundation"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
@@ -777,8 +817,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c07782be35f9e1140080c6b96f0d44b739e2278479f64e02fdab4e32dfd8b081"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
- "core-graphics-types",
+ "core-foundation 0.9.4",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
  "libc",
 ]
@@ -790,7 +843,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
 dependencies = [
  "bitflags 1.3.2",
- "core-foundation",
+ "core-foundation 0.9.4",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.10.0",
  "libc",
 ]
 
@@ -2288,17 +2352,6 @@ dependencies = [
 
 [[package]]
 name = "json-patch"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec9ad60d674508f3ca8f380a928cfe7b096bc729c4e2dbfe3852bc45da3ab30b"
-dependencies = [
- "serde",
- "serde_json",
- "thiserror",
-]
-
-[[package]]
-name = "json-patch"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b1fb8864823fad91877e6caea0baca82e49e8db50f8e5c9f9a453e27d3330fc"
@@ -2573,11 +2626,11 @@ dependencies = [
 
 [[package]]
 name = "muda"
-version = "0.13.5"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b959f97c97044e4c96e32e1db292a7d594449546a3c6b77ae613dc3a5b5145"
+checksum = "86c410a9d21523a819e84881603fbc00331c8001eb899964952046671deddb9c"
 dependencies = [
- "cocoa",
+ "cocoa 0.26.0",
  "crossbeam-channel",
  "dpi",
  "gtk",
@@ -2587,7 +2640,7 @@ dependencies = [
  "png",
  "serde",
  "thiserror",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2609,15 +2662,16 @@ dependencies = [
 
 [[package]]
 name = "ndk"
-version = "0.7.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "451422b7e4718271c8b5b3aadf5adedba43dc76312454b387e98fae0fc951aa0"
+checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.6.0",
  "jni-sys",
+ "log",
  "ndk-sys",
  "num_enum",
- "raw-window-handle 0.5.2",
+ "raw-window-handle",
  "thiserror",
 ]
 
@@ -2629,9 +2683,9 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
-version = "0.4.1+23.1.7779620"
+version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cf2aae958bd232cac5069850591667ad422d263686d75b52a065f9badeee5a3"
+checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
 ]
@@ -2755,23 +2809,23 @@ dependencies = [
 
 [[package]]
 name = "num_enum"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
+checksum = "4e613fc340b2220f734a8595782c551f1250e969d87d3be1ae0579e8d4065179"
 dependencies = [
  "num_enum_derive",
 ]
 
 [[package]]
 name = "num_enum_derive"
-version = "0.5.11"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
+checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.72",
 ]
 
 [[package]]
@@ -3600,12 +3654,6 @@ dependencies = [
 
 [[package]]
 name = "raw-window-handle"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ff9a1f06a88b01621b7ae906ef0211290d1c8a168a15542486a8f61c0833b9"
-
-[[package]]
-name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
@@ -3773,7 +3821,7 @@ dependencies = [
  "objc",
  "objc-foundation",
  "objc_id",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -3965,7 +4013,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
  "bitflags 2.6.0",
- "core-foundation",
+ "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4252,7 +4300,7 @@ checksum = "d623bff5d06f60d738990980d782c8c866997d9194cfe79ecad00aa2f76826dd"
 dependencies = [
  "bytemuck",
  "cfg_aliases",
- "core-graphics",
+ "core-graphics 0.23.2",
  "foreign-types 0.5.0",
  "js-sys",
  "log",
@@ -4260,7 +4308,7 @@ dependencies = [
  "objc2-app-kit",
  "objc2-foundation",
  "objc2-quartz-core",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "redox_syscall 0.5.3",
  "wasm-bindgen",
  "web-sys",
@@ -4595,7 +4643,7 @@ name = "tablex"
 version = "0.3.4"
 dependencies = [
  "clap",
- "json-patch 2.0.0",
+ "json-patch",
  "open",
  "regex",
  "serde",
@@ -4622,14 +4670,14 @@ dependencies = [
 
 [[package]]
 name = "tao"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea538df05fbc2dcbbd740ba0cfe8607688535f4798d213cbbfa13ce494f3451f"
+checksum = "6775bcf3c1da33f848ede9cff5883ed1e45a29f66533ce42ad06c93ae514ed59"
 dependencies = [
  "bitflags 2.6.0",
- "cocoa",
- "core-foundation",
- "core-graphics",
+ "cocoa 0.26.0",
+ "core-foundation 0.10.0",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dispatch",
  "dlopen2",
@@ -4648,13 +4696,13 @@ dependencies = [
  "objc",
  "once_cell",
  "parking_lot 0.12.3",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "scopeguard",
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows 0.57.0",
- "windows-core 0.57.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
  "windows-version",
  "x11-dl",
 ]
@@ -4689,13 +4737,13 @@ checksum = "4873307b7c257eddcb50c9bedf158eb669578359fb28428bef438fec8e6ba7c2"
 
 [[package]]
 name = "tauri"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "255e746089a370802ec4eb896dccc6f27c1dd2a203c1dc484fd996db954e2300"
+checksum = "79776954e2cd6b6c3b56e2cd99905a3a166017495a39ac8eb4c85dd8ea8704b4"
 dependencies = [
  "anyhow",
  "bytes",
- "cocoa",
+ "cocoa 0.26.0",
  "dirs 5.0.1",
  "dunce",
  "embed_plist",
@@ -4712,7 +4760,7 @@ dependencies = [
  "muda",
  "objc",
  "percent-encoding",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "reqwest",
  "serde",
  "serde_json",
@@ -4734,21 +4782,21 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows 0.57.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
 name = "tauri-build"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ceb8d082c3b17b4b2eb134a39363a22c696ddba473d6e5c0ab1caadad4cfca"
+checksum = "1fc103bde77870e08d5fc8765615b9615997827550b626fbc4ebbd7a1fbfe2a2"
 dependencies = [
  "anyhow",
  "cargo_toml",
  "dirs 5.0.1",
  "glob",
  "heck 0.5.0",
- "json-patch 1.4.0",
+ "json-patch",
  "schemars",
  "semver",
  "serde",
@@ -4761,14 +4809,14 @@ dependencies = [
 
 [[package]]
 name = "tauri-codegen"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2407c7d37a491b16e530445c9611d91091cae198eea2ed424913b740215605f2"
+checksum = "ea061e6be9b37ab455eadc189f45617deafc85c94f78f9cd584862a6deaa83d1"
 dependencies = [
  "base64 0.22.1",
  "brotli",
  "ico",
- "json-patch 1.4.0",
+ "json-patch",
  "plist",
  "png",
  "proc-macro2",
@@ -4788,9 +4836,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-macros"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d210893b693be00f569b4f54456803debe104b7675f368205f2b6e94bac09b34"
+checksum = "9e20d6f6f96f55a43339c465b3c8205d71940372d54d7c665c5329e8e4ba35d0"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4841,7 +4889,7 @@ checksum = "8860dd73c96969eb14813f9f04d8665f2853342670456fb6619d637137ef0d09"
 dependencies = [
  "dunce",
  "log",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "rfd",
  "serde",
  "serde_json",
@@ -4922,36 +4970,36 @@ dependencies = [
 
 [[package]]
 name = "tauri-runtime"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6624fdf383ccafc9e8ad9205fe6e5c976b318efcd6b3662dde658c74e4254792"
+checksum = "f4e736d3293f8347e5d2c5b250fe0e5b873499f5483578b139445dbbf802e2e5"
 dependencies = [
  "dpi",
  "gtk",
  "http",
  "jni",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "serde",
  "serde_json",
  "tauri-utils",
  "thiserror",
  "url",
- "windows 0.57.0",
+ "windows 0.58.0",
 ]
 
 [[package]]
 name = "tauri-runtime-wry"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd1a785c4281f8231b091593393b40cb3a800810c407b1ffed52de27ff1640a"
+checksum = "9fead81c1bd0205d5f02580e64f522704618274e784c2d1c127e4ba19acd0b79"
 dependencies = [
- "cocoa",
+ "cocoa 0.26.0",
  "gtk",
  "http",
  "jni",
  "log",
  "percent-encoding",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "softbuffer",
  "tao",
  "tauri-runtime",
@@ -4959,15 +5007,15 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows 0.57.0",
+ "windows 0.58.0",
  "wry",
 ]
 
 [[package]]
 name = "tauri-specta"
-version = "2.0.0-rc.15"
+version = "2.0.0-rc.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5146a4f94911b69b6086a0a700e8748b96cc18220b0504d5085dc0f856d2bec7"
+checksum = "0b37d5f9a690f0c5264e5461a2cd9a273565f9a12acf642692a16ea292e32f6b"
 dependencies = [
  "heck 0.5.0",
  "serde",
@@ -4981,9 +5029,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-specta-macros"
-version = "2.0.0-rc.6"
+version = "2.0.0-rc.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0e8c565ad3dda541e954e9e8fbbca9d43283d1050aec78daac07a92b64f733"
+checksum = "7a4aa93823e07859546aa796b8a5d608190cd8037a3a5dce3eb63d491c34bda8"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -4993,9 +5041,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-utils"
-version = "2.0.0-rc.0"
+version = "2.0.0-rc.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f435eeaae1e69cf93cf19da0f727989eed2e5eb6fc63a8d21432f59dd3ac4ac"
+checksum = "285af18e09665ea15fdda04cb28fb579a4d71b4e1640628489fecca98838ca9a"
 dependencies = [
  "brotli",
  "cargo_metadata",
@@ -5004,7 +5052,7 @@ dependencies = [
  "glob",
  "html5ever",
  "infer",
- "json-patch 1.4.0",
+ "json-patch",
  "kuchikiki",
  "log",
  "memchr",
@@ -5377,22 +5425,23 @@ dependencies = [
 
 [[package]]
 name = "tray-icon"
-version = "0.14.3"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ad8319cca93189ea9ab1b290de0595960529750b6b8b501a399ed1ec3775d60"
+checksum = "2b92252d649d771105448969f2b2dda4342ba48b77731b60d37c93665e26615b"
 dependencies = [
- "cocoa",
- "core-graphics",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dirs 5.0.1",
  "libappindicator",
  "muda",
- "objc",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
  "once_cell",
  "png",
  "serde",
  "thiserror",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5433,7 +5482,9 @@ dependencies = [
  "serde_json",
  "specta",
  "sqlx",
+ "tauri",
  "tauri-specta",
+ "thiserror",
 ]
 
 [[package]]
@@ -5841,23 +5892,23 @@ dependencies = [
 
 [[package]]
 name = "webview2-com"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6516cfa64c6b3212686080eeec378e662c2af54bb2a5b2a22749673f5cb2226f"
+checksum = "6f61ff3d9d0ee4efcb461b14eb3acfda2702d10dc329f339303fc3e57215ae2c"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows 0.57.0",
- "windows-core 0.57.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
  "windows-implement",
  "windows-interface",
 ]
 
 [[package]]
 name = "webview2-com-macros"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac1345798ecd8122468840bcdf1b95e5dc6d2206c5e4b0eafa078d061f59c9bc"
+checksum = "1d228f15bba3b9d56dde8bddbee66fa24545bd17b48d5128ccf4a8742b18e431"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5866,13 +5917,13 @@ dependencies = [
 
 [[package]]
 name = "webview2-com-sys"
-version = "0.31.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c76d5b77320ff155660be1df3e6588bc85c75f1a9feef938cc4dc4dd60d1d7cf"
+checksum = "a3a3e2eeb58f82361c93f9777014668eb3d07e7d174ee4c819575a9208011886"
 dependencies = [
  "thiserror",
- "windows 0.57.0",
- "windows-core 0.57.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
 ]
 
 [[package]]
@@ -5929,9 +5980,9 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33082acd404763b315866e14a0d5193f3422c81086657583937a750cdd3ec340"
 dependencies = [
- "cocoa",
+ "cocoa 0.25.0",
  "objc",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "windows-sys 0.52.0",
  "windows-version",
 ]
@@ -5957,11 +6008,11 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
 dependencies = [
- "windows-core 0.57.0",
+ "windows-core 0.58.0",
  "windows-targets 0.52.6",
 ]
 
@@ -5980,27 +6031,28 @@ version = "0.54.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
 dependencies = [
- "windows-result",
+ "windows-result 0.1.2",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result",
+ "windows-result 0.2.0",
+ "windows-strings",
  "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6009,9 +6061,9 @@ dependencies = [
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6024,6 +6076,25 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
 dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
  "windows-targets 0.52.6",
 ]
 
@@ -6050,6 +6121,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -6262,14 +6342,14 @@ dependencies = [
 
 [[package]]
 name = "wry"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68b00c945786b02d7805d09a969fa36d0eee4e0bd4fb3ec2a79d2bf45a1b44cd"
+checksum = "49b8049c8f239cdbfaaea4bacb9646f6b208938ceec0acd5b3e99cd05f70903f"
 dependencies = [
  "base64 0.22.1",
  "block",
- "cocoa",
- "core-graphics",
+ "cocoa 0.26.0",
+ "core-graphics 0.24.0",
  "crossbeam-channel",
  "dpi",
  "dunce",
@@ -6282,13 +6362,11 @@ dependencies = [
  "kuchikiki",
  "libc",
  "ndk",
- "ndk-context",
- "ndk-sys",
  "objc",
  "objc_id",
  "once_cell",
  "percent-encoding",
- "raw-window-handle 0.6.2",
+ "raw-window-handle",
  "sha2",
  "soup3",
  "tao-macros",
@@ -6296,8 +6374,8 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows 0.57.0",
- "windows-core 0.57.0",
+ "windows 0.58.0",
+ "windows-core 0.58.0",
  "windows-version",
  "x11-dl",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ strip = true
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 tokio = { version = "1", features = ["full"] }
-tauri = { version = "2.0.0-rc.0" }
+tauri = { version = "2.0.0-rc.3" }
 sqlx = { version = "0.6.3", features = [
     "runtime-tokio-native-tls",
     "any",
@@ -36,4 +36,4 @@ sqlx = { version = "0.6.3", features = [
 ] }
 async-trait = "0.1.80"
 specta = { version = "2.0.0-rc.20", features = ["serde", "serde_json"] }
-tauri-specta = { version = "2.0.0-rc.15", features = ["derive", "typescript"] }
+tauri-specta = { version = "2.0.0-rc.17", features = ["derive", "typescript"] }

--- a/apps/core/src-tauri/src/commands/fs.rs
+++ b/apps/core/src-tauri/src/commands/fs.rs
@@ -4,7 +4,10 @@ use serde_json::Value;
 use specta::Type;
 use tauri::AppHandle;
 use tx_keybindings::{get_keybindings_file_path, Keybinding};
-use tx_lib::fs::{read_from_json, write_into_json};
+use tx_lib::{
+    fs::{read_from_json, write_into_json},
+    TxError,
+};
 use tx_settings::{get_settings_file_path, Settings};
 
 #[derive(Serialize, Deserialize, Type)]
@@ -19,31 +22,29 @@ pub(crate) enum ConfigFile {
 // but for now there is no need to.
 #[tauri::command]
 #[specta::specta]
-pub fn open_in_external_editor(app: AppHandle, file: ConfigFile) -> Result<(), String> {
+pub fn open_in_external_editor(app: AppHandle, file: ConfigFile) -> Result<(), TxError> {
     let path = match file {
         ConfigFile::Keybindings => get_keybindings_file_path(&app)?,
         ConfigFile::Settings => get_settings_file_path(&app)?,
     };
-    open::that_detached(path).map_err(|e| e.to_string())
+    Ok(open::that_detached(path)?)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn load_settings_file(app: AppHandle) -> Result<Settings, String> {
+pub fn load_settings_file(app: AppHandle) -> Result<Settings, TxError> {
     let settings = read_from_json::<Value>(&get_settings_file_path(&app)?)?;
-    let mut default_settings =
-        serde_json::to_value(Settings::default()).map_err(|_| "Serialization error".to_string())?;
+    let mut default_settings = serde_json::to_value(Settings::default())?;
 
     merge(&mut default_settings, &settings);
 
-    let settings = serde_json::from_value::<Settings>(settings)
-        .map_err(|_| "Serialization error".to_string())?;
+    let settings = serde_json::from_value::<Settings>(settings)?;
     Ok(settings)
 }
 
 #[tauri::command]
 #[specta::specta]
-pub fn write_into_settings_file(app: AppHandle, settings: Value) -> Result<(), String> {
+pub fn write_into_settings_file(app: AppHandle, settings: Value) -> Result<(), TxError> {
     let mut stored_settings = read_from_json::<Value>(&get_settings_file_path(&app)?)?;
     merge(&mut stored_settings, &settings);
 
@@ -56,7 +57,7 @@ pub fn write_into_settings_file(app: AppHandle, settings: Value) -> Result<(), S
 pub fn write_into_keybindings_file(
     app: AppHandle,
     keybindings: Vec<Keybinding>,
-) -> Result<(), String> {
+) -> Result<(), TxError> {
     write_into_json(&get_keybindings_file_path(&app)?, keybindings)?;
     Ok(())
 }

--- a/apps/core/src-tauri/src/commands/row.rs
+++ b/apps/core/src-tauri/src/commands/row.rs
@@ -4,8 +4,11 @@ use serde_json::Value as JsonValue;
 use std::collections::HashMap;
 use tauri::{async_runtime::Mutex, AppHandle, State};
 use tauri_specta::Event;
-use tx_lib::events::TableContentsChanged;
-use tx_lib::types::{FKRows, PaginatedRows};
+use tx_lib::{
+    events::TableContentsChanged,
+    types::{FKRows, PaginatedRows},
+    Result,
+};
 
 #[tauri::command]
 #[specta::specta]
@@ -14,7 +17,7 @@ pub async fn get_paginated_rows(
     table_name: String,
     page_index: u16,
     page_size: i32,
-) -> Result<PaginatedRows, String> {
+) -> Result<PaginatedRows> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_deref().unwrap();
@@ -32,7 +35,7 @@ pub async fn delete_rows(
     pk_col_name: String,
     row_pk_values: Vec<JsonValue>,
     table_name: String,
-) -> Result<String, String> {
+) -> Result<String> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_deref().unwrap();
@@ -64,7 +67,7 @@ pub async fn create_row(
     state: State<'_, Mutex<SharedState>>,
     table_name: String,
     data: HashMap<String, JsonValue>,
-) -> Result<String, String> {
+) -> Result<String> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_deref().unwrap();
@@ -109,7 +112,7 @@ pub async fn update_row(
     pk_col_name: String,
     pk_col_value: JsonValue,
     data: Map<String, JsonValue>,
-) -> Result<String, String> {
+) -> Result<String> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_deref().unwrap();
@@ -139,7 +142,7 @@ pub async fn get_fk_relations(
     table_name: String,
     column_name: String,
     cell_value: JsonValue,
-) -> Result<Vec<FKRows>, String> {
+) -> Result<Vec<FKRows>> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_deref().unwrap();

--- a/apps/core/src-tauri/src/commands/table.rs
+++ b/apps/core/src-tauri/src/commands/table.rs
@@ -2,11 +2,11 @@ use crate::state::SharedState;
 use serde_json::{Map, Value};
 use sqlx::Row;
 use tauri::{async_runtime::Mutex, State};
-use tx_lib::types::ColumnProps;
+use tx_lib::{types::ColumnProps, Result};
 
 #[tauri::command]
 #[specta::specta]
-pub async fn get_tables(state: State<'_, Mutex<SharedState>>) -> Result<Vec<String>, String> {
+pub async fn get_tables(state: State<'_, Mutex<SharedState>>) -> Result<Vec<String>> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_ref().unwrap();
@@ -28,7 +28,7 @@ pub async fn get_tables(state: State<'_, Mutex<SharedState>>) -> Result<Vec<Stri
 pub async fn get_columns_props(
     state: State<'_, Mutex<SharedState>>,
     table_name: String,
-) -> Result<Vec<ColumnProps>, String> {
+) -> Result<Vec<ColumnProps>> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_ref().unwrap();
@@ -42,7 +42,7 @@ pub async fn get_columns_props(
 pub async fn execute_raw_query(
     state: State<'_, Mutex<SharedState>>,
     query: String,
-) -> Result<Vec<Map<String, Value>>, String> {
+) -> Result<Vec<Map<String, Value>>> {
     let state = state.lock().await;
     let pool = state.pool.as_ref().unwrap();
     let handler = state.handler.as_ref().unwrap();

--- a/apps/core/src-tauri/src/main.rs
+++ b/apps/core/src-tauri/src/main.rs
@@ -26,7 +26,7 @@ use state::SharedState;
 use tauri::{async_runtime::Mutex, AppHandle, Manager, Window, WindowEvent};
 use tauri_specta::{collect_commands, collect_events, Builder};
 use tx_keybindings::*;
-use tx_lib::events::*;
+use tx_lib::{events::*, TxError};
 use tx_settings::*;
 
 #[tauri::command]
@@ -43,7 +43,7 @@ fn close_splashscreen(window: Window) {
     }
 }
 
-fn ensure_config_files_exist(app: &AppHandle) -> Result<(), String> {
+fn ensure_config_files_exist(app: &AppHandle) -> Result<(), TxError> {
     ensure_settings_file_exist(&get_settings_file_path(app)?)?;
     ensure_keybindings_file_exist(&get_keybindings_file_path(app)?)?;
     ensure_connections_file_exist(&get_connections_file_path(app)?)?;
@@ -52,8 +52,8 @@ fn ensure_config_files_exist(app: &AppHandle) -> Result<(), String> {
 
 fn main() {
     let builder = Builder::<tauri::Wry>::new()
-        .ty::<Keybinding>()
-        .ty::<Settings>()
+        .typ::<Keybinding>()
+        .typ::<Settings>()
         .constant("KEYBINDINGS_FILE_NAME", KEYBINDINGS_FILE_NAME)
         .constant("SETTINGS_FILE_NAME", SETTINGS_FILE_NAME)
         .commands(collect_commands![

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -175,8 +175,8 @@ tableContentsChanged: "table-contents-changed"
 
 /** user-defined constants **/
 
-export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
 export const SETTINGS_FILE_NAME = "settings.json" as const;
+export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
 
 /** user-defined types **/
 

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -8,7 +8,7 @@ export const commands = {
 async closeSplashscreen() : Promise<void> {
     await TAURI_INVOKE("close_splashscreen");
 },
-async testConnection(connString: string) : Promise<Result<string, string>> {
+async testConnection(connString: string) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("test_connection", { connString }) };
 } catch (e) {
@@ -32,7 +32,7 @@ async deleteConnectionRecord(connId: string) : Promise<Result<string, TxError>> 
     else return { status: "error", error: e  as any };
 }
 },
-async establishConnection(connString: string, driver: Drivers) : Promise<Result<null, string>> {
+async establishConnection(connString: string, driver: Drivers) : Promise<Result<null, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("establish_connection", { connString, driver }) };
 } catch (e) {
@@ -175,8 +175,8 @@ tableContentsChanged: "table-contents-changed"
 
 /** user-defined constants **/
 
-export const SETTINGS_FILE_NAME = "settings.json" as const;
 export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
+export const SETTINGS_FILE_NAME = "settings.json" as const;
 
 /** user-defined types **/
 

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -16,7 +16,7 @@ async testConnection(connString: string) : Promise<Result<string, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async createConnectionRecord(connString: string, connName: string, driver: Drivers) : Promise<Result<string, string>> {
+async createConnectionRecord(connString: string, connName: string, driver: Drivers) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_connection_record", { connString, connName, driver }) };
 } catch (e) {
@@ -24,7 +24,7 @@ async createConnectionRecord(connString: string, connName: string, driver: Drive
     else return { status: "error", error: e  as any };
 }
 },
-async deleteConnectionRecord(connId: string) : Promise<Result<string, string>> {
+async deleteConnectionRecord(connId: string) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_connection_record", { connId }) };
 } catch (e) {
@@ -40,7 +40,7 @@ async establishConnection(connString: string, driver: Drivers) : Promise<Result<
     else return { status: "error", error: e  as any };
 }
 },
-async connectionsExist() : Promise<Result<boolean, string>> {
+async connectionsExist() : Promise<Result<boolean, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("connections_exist") };
 } catch (e) {
@@ -48,7 +48,7 @@ async connectionsExist() : Promise<Result<boolean, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getConnections() : Promise<Result<{ [key in string]: ConnConfig }, string>> {
+async getConnections() : Promise<Result<{ [key in string]: ConnConfig }, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_connections") };
 } catch (e) {
@@ -56,7 +56,7 @@ async getConnections() : Promise<Result<{ [key in string]: ConnConfig }, string>
     else return { status: "error", error: e  as any };
 }
 },
-async getConnectionDetails(connId: string) : Promise<Result<ConnConfig, string>> {
+async getConnectionDetails(connId: string) : Promise<Result<ConnConfig, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_connection_details", { connId }) };
 } catch (e) {
@@ -64,7 +64,7 @@ async getConnectionDetails(connId: string) : Promise<Result<ConnConfig, string>>
     else return { status: "error", error: e  as any };
 }
 },
-async openInExternalEditor(file: ConfigFile) : Promise<Result<null, string>> {
+async openInExternalEditor(file: ConfigFile) : Promise<Result<null, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("open_in_external_editor", { file }) };
 } catch (e) {
@@ -72,7 +72,7 @@ async openInExternalEditor(file: ConfigFile) : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async loadSettingsFile() : Promise<Result<Settings, string>> {
+async loadSettingsFile() : Promise<Result<Settings, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("load_settings_file") };
 } catch (e) {
@@ -80,7 +80,7 @@ async loadSettingsFile() : Promise<Result<Settings, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async writeIntoSettingsFile(settings: JsonValue) : Promise<Result<null, string>> {
+async writeIntoSettingsFile(settings: JsonValue) : Promise<Result<null, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("write_into_settings_file", { settings }) };
 } catch (e) {
@@ -88,7 +88,7 @@ async writeIntoSettingsFile(settings: JsonValue) : Promise<Result<null, string>>
     else return { status: "error", error: e  as any };
 }
 },
-async writeIntoKeybindingsFile(keybindings: Keybinding[]) : Promise<Result<null, string>> {
+async writeIntoKeybindingsFile(keybindings: Keybinding[]) : Promise<Result<null, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("write_into_keybindings_file", { keybindings }) };
 } catch (e) {
@@ -175,8 +175,8 @@ tableContentsChanged: "table-contents-changed"
 
 /** user-defined constants **/
 
-export const SETTINGS_FILE_NAME = "settings.json" as const;
 export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
+export const SETTINGS_FILE_NAME = "settings.json" as const;
 
 /** user-defined types **/
 
@@ -265,6 +265,22 @@ sqlEditor: SQLEditorSettings }
 export type Sidebar = "focusSearch"
 export type Table = "deleteRow" | "copyRow" | "selectAll"
 export type TableContentsChanged = null
+/**
+ * Global error object returned by all commands
+ */
+export type TxError = { 
+/**
+ * Kind of the error
+ */
+kind: "Database" | "Io" | "TauriError" | "SerdeError"; 
+/**
+ * short message to be displayed in the toast
+ */
+message: string; 
+/**
+ * Detailed error message throwing by the low level api
+ */
+details: string }
 /**
  * General visibility settings.
  */

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -175,8 +175,8 @@ tableContentsChanged: "table-contents-changed"
 
 /** user-defined constants **/
 
-export const SETTINGS_FILE_NAME = "settings.json" as const;
 export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
+export const SETTINGS_FILE_NAME = "settings.json" as const;
 
 /** user-defined types **/
 

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -270,10 +270,6 @@ export type TableContentsChanged = null
  */
 export type TxError = { 
 /**
- * Kind of the error
- */
-kind: "Database" | "Io" | "TauriError" | "SerdeError"; 
-/**
  * short message to be displayed in the toast
  */
 message: string; 

--- a/apps/core/src/bindings.ts
+++ b/apps/core/src/bindings.ts
@@ -96,7 +96,7 @@ async writeIntoKeybindingsFile(keybindings: Keybinding[]) : Promise<Result<null,
     else return { status: "error", error: e  as any };
 }
 },
-async getTables() : Promise<Result<string[], string>> {
+async getTables() : Promise<Result<string[], TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_tables") };
 } catch (e) {
@@ -104,7 +104,7 @@ async getTables() : Promise<Result<string[], string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async getColumnsProps(tableName: string) : Promise<Result<ColumnProps[], string>> {
+async getColumnsProps(tableName: string) : Promise<Result<ColumnProps[], TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_columns_props", { tableName }) };
 } catch (e) {
@@ -112,7 +112,7 @@ async getColumnsProps(tableName: string) : Promise<Result<ColumnProps[], string>
     else return { status: "error", error: e  as any };
 }
 },
-async executeRawQuery(query: string) : Promise<Result<{ [key in string]: JsonValue }[], string>> {
+async executeRawQuery(query: string) : Promise<Result<{ [key in string]: JsonValue }[], TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("execute_raw_query", { query }) };
 } catch (e) {
@@ -120,7 +120,7 @@ async executeRawQuery(query: string) : Promise<Result<{ [key in string]: JsonVal
     else return { status: "error", error: e  as any };
 }
 },
-async getPaginatedRows(tableName: string, pageIndex: number, pageSize: number) : Promise<Result<PaginatedRows, string>> {
+async getPaginatedRows(tableName: string, pageIndex: number, pageSize: number) : Promise<Result<PaginatedRows, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_paginated_rows", { tableName, pageIndex, pageSize }) };
 } catch (e) {
@@ -128,7 +128,7 @@ async getPaginatedRows(tableName: string, pageIndex: number, pageSize: number) :
     else return { status: "error", error: e  as any };
 }
 },
-async deleteRows(pkColName: string, rowPkValues: JsonValue[], tableName: string) : Promise<Result<string, string>> {
+async deleteRows(pkColName: string, rowPkValues: JsonValue[], tableName: string) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("delete_rows", { pkColName, rowPkValues, tableName }) };
 } catch (e) {
@@ -136,7 +136,7 @@ async deleteRows(pkColName: string, rowPkValues: JsonValue[], tableName: string)
     else return { status: "error", error: e  as any };
 }
 },
-async createRow(tableName: string, data: { [key in string]: JsonValue }) : Promise<Result<string, string>> {
+async createRow(tableName: string, data: { [key in string]: JsonValue }) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("create_row", { tableName, data }) };
 } catch (e) {
@@ -144,7 +144,7 @@ async createRow(tableName: string, data: { [key in string]: JsonValue }) : Promi
     else return { status: "error", error: e  as any };
 }
 },
-async updateRow(tableName: string, pkColName: string, pkColValue: JsonValue, data: { [key in string]: JsonValue }) : Promise<Result<string, string>> {
+async updateRow(tableName: string, pkColName: string, pkColValue: JsonValue, data: { [key in string]: JsonValue }) : Promise<Result<string, TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("update_row", { tableName, pkColName, pkColValue, data }) };
 } catch (e) {
@@ -152,7 +152,7 @@ async updateRow(tableName: string, pkColName: string, pkColValue: JsonValue, dat
     else return { status: "error", error: e  as any };
 }
 },
-async getFkRelations(tableName: string, columnName: string, cellValue: JsonValue) : Promise<Result<FKRows[], string>> {
+async getFkRelations(tableName: string, columnName: string, cellValue: JsonValue) : Promise<Result<FKRows[], TxError>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("get_fk_relations", { tableName, columnName, cellValue }) };
 } catch (e) {
@@ -175,8 +175,8 @@ tableContentsChanged: "table-contents-changed"
 
 /** user-defined constants **/
 
-export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
 export const SETTINGS_FILE_NAME = "settings.json" as const;
+export const KEYBINDINGS_FILE_NAME = "keybindings.json" as const;
 
 /** user-defined types **/
 

--- a/apps/core/src/commands/columns.ts
+++ b/apps/core/src/commands/columns.ts
@@ -5,6 +5,8 @@ import { z } from "zod"
 export const getZodSchemaFromCols = async (tableName: string) => {
   const result = await commands.getColumnsProps(tableName)
   const cols = unwrapResult(result)
+  if (cols === false) return
+
   const schemaObject: z.ZodRawShape = {}
 
   cols.forEach((colProps) => {

--- a/apps/core/src/components/dialogs/error-dialog.tsx
+++ b/apps/core/src/components/dialogs/error-dialog.tsx
@@ -1,0 +1,23 @@
+import { PropsWithChildren } from "react"
+import { Button } from "../ui/button"
+import { Dialog, DialogContent, DialogTrigger } from "../ui/dialog"
+
+type ErrorDialogProps = PropsWithChildren & {
+  error: string
+}
+
+const ErrorDialog = ({ error, children }: ErrorDialogProps) => {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="flex flex-col items-start">
+        <Button variant={"link"}>Show logs</Button>
+        <code className="w-full overflow-auto rounded-md border-2 p-2">
+          {error}
+        </code>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+export default ErrorDialog

--- a/apps/core/src/components/sheets/create-row-sheet.tsx
+++ b/apps/core/src/components/sheets/create-row-sheet.tsx
@@ -23,7 +23,6 @@ import { useCreateRowSheetState } from "@/state/sheetState"
 import { zodResolver } from "@hookform/resolvers/zod"
 import { Plus } from "lucide-react"
 import { useForm } from "react-hook-form"
-import toast from "react-hot-toast"
 import { z } from "zod"
 import CustomTooltip from "../custom-tooltip"
 import DynamicFormInput from "./components/dynamic-input"
@@ -65,14 +64,12 @@ const AddRowForm = ({ tableName }: { tableName: string }) => {
     "0": {
       data: zodSchema,
       isLoading: isZodSchemaLoading,
-      isSuccess: isZodSchemaSuccess,
-      error: zodSchemaError
+      isSuccess: isZodSchemaSuccess
     },
     "1": {
       data: columnsProps,
       isLoading: isColumnsPropsLoading,
-      isSuccess: isColumnsPropsSuccess,
-      error: columnsPropsError
+      isSuccess: isColumnsPropsSuccess
     }
   } = useGetGeneralColsData(tableName)
 
@@ -82,12 +79,9 @@ const AddRowForm = ({ tableName }: { tableName: string }) => {
 
   if (isZodSchemaLoading || isColumnsPropsLoading) return <LoadingSpinner />
 
-  if (!isZodSchemaSuccess)
-    return toast.error(zodSchemaError!.message, { id: "get_zod_schema" })
-  if (!isColumnsPropsSuccess)
-    return toast.error(columnsPropsError!.message, { id: "get_zod_schema" })
+  if (!isZodSchemaSuccess || !isColumnsPropsSuccess) return
 
-  const onSubmit = async (values: z.infer<typeof zodSchema>) => {
+  const onSubmit = async (values: z.infer<NonNullable<typeof zodSchema>>) => {
     await createRowCmd(tableName, values, toggleSheet)
   }
   return (

--- a/apps/core/src/components/sheets/edit-row-sheet.tsx
+++ b/apps/core/src/components/sheets/edit-row-sheet.tsx
@@ -40,14 +40,12 @@ const EditRowSheet = ({ row }: EditRowSheetProps) => {
     "0": {
       data: zodSchema,
       isLoading: isZodSchemaLoading,
-      isSuccess: isZodSchemaSuccess,
-      error: zodSchemaError
+      isSuccess: isZodSchemaSuccess
     },
     "1": {
       data: columnsProps,
       isLoading: isColumnsPropsLoading,
-      isSuccess: isColumnsPropsSuccess,
-      error: columnsPropsError
+      isSuccess: isColumnsPropsSuccess
     }
   } = useGetGeneralColsData(tableName)
 
@@ -58,6 +56,10 @@ const EditRowSheet = ({ row }: EditRowSheetProps) => {
   })
 
   if (!row) return null
+
+  if (isZodSchemaLoading || isColumnsPropsLoading) return <LoadingSpinner />
+
+  if (!isZodSchemaSuccess || !isColumnsPropsSuccess) return
 
   const onSubmit = async (
     values: z.infer<NonNullable<typeof partialZodSchema>>
@@ -75,13 +77,6 @@ const EditRowSheet = ({ row }: EditRowSheetProps) => {
       toggleSheet
     )
   }
-
-  if (isZodSchemaLoading || isColumnsPropsLoading) return <LoadingSpinner />
-
-  if (!isZodSchemaSuccess)
-    return toast.error(zodSchemaError!.message, { id: "get_zod_schema" })
-  if (!isColumnsPropsSuccess)
-    return toast.error(columnsPropsError!.message, { id: "get_zod_schema" })
 
   return (
     <SheetContent>

--- a/apps/core/src/hooks/row.ts
+++ b/apps/core/src/hooks/row.ts
@@ -63,8 +63,13 @@ export const useGetGeneralColsData = (tableName: string) => {
       },
       {
         queryKey: ["columns_props", tableName],
-        queryFn: async () =>
-          unwrapResult(await commands.getColumnsProps(tableName))
+        queryFn: async () => {
+          const columnsProps = unwrapResult(
+            await commands.getColumnsProps(tableName)
+          )
+          if (!columnsProps) throw new Error()
+          return columnsProps
+        }
       }
     ]
   })

--- a/apps/core/src/lib/utils.tsx
+++ b/apps/core/src/lib/utils.tsx
@@ -49,7 +49,8 @@ export function customToast<T extends string>(
         )}
       </div>,
       {
-        icon: <ErrorIcon />
+        icon: <ErrorIcon />,
+        id: "toast_error"
       }
     )
   }

--- a/apps/core/src/lib/utils.tsx
+++ b/apps/core/src/lib/utils.tsx
@@ -1,6 +1,6 @@
 import type { ColumnProps, TxError } from "@/bindings"
-import { Button } from "@/components/ui/button"
-import { toast } from "react-hot-toast"
+import { Separator } from "@/components/ui/separator"
+import { ErrorIcon, toast } from "react-hot-toast"
 import { Drivers, type ConnectionStringParams } from "./types"
 
 /**
@@ -33,13 +33,20 @@ export function customToast<T extends string>(
   id?: string
 ) {
   if (commandResult.status === "error") {
-    return toast.custom(
-      <div>
+    console.log(commandResult.error.details)
+    return toast(
+      <div className="flex items-center justify-between gap-x-2">
         <p>{commandResult.error.message}</p>
-        <Button variant={"link"} size={"sm"}>
-          more
-        </Button>
-      </div>
+        {commandResult.error.details && (
+          <>
+            <Separator orientation="vertical" />
+            <button className="font-semibold text-black">more</button>
+          </>
+        )}
+      </div>,
+      {
+        icon: <ErrorIcon />
+      }
     )
   }
   onSuccess()
@@ -52,10 +59,10 @@ export function customToast<T extends string>(
  * @param result Result of executing a Tauri command.
  * @returns The inner data of the `Ok`
  */
-export function unwrapResult<T>(result: Result<T>) {
+export function unwrapResult<T>(result: Result<T>): false | T {
   if (result.status === "error") {
     customToast(result, () => {})
-    throw new Error(result.error.kind)
+    return false
   }
   return result.data
 }

--- a/apps/core/src/lib/utils.tsx
+++ b/apps/core/src/lib/utils.tsx
@@ -1,4 +1,5 @@
 import type { ColumnProps, TxError } from "@/bindings"
+import ErrorDialog from "@/components/dialogs/error-dialog"
 import { Separator } from "@/components/ui/separator"
 import { ErrorIcon, toast } from "react-hot-toast"
 import { Drivers, type ConnectionStringParams } from "./types"
@@ -33,14 +34,17 @@ export function customToast<T extends string>(
   id?: string
 ) {
   if (commandResult.status === "error") {
-    console.log(commandResult.error.details)
     return toast(
       <div className="flex items-center justify-between gap-x-2">
         <p>{commandResult.error.message}</p>
         {commandResult.error.details && (
           <>
             <Separator orientation="vertical" />
-            <button className="font-semibold text-black">more</button>
+            <ErrorDialog error={commandResult.error.details}>
+              <button className="hover:bg-muted-foreground rounded-md p-1 font-semibold text-black transition-all">
+                more
+              </button>
+            </ErrorDialog>
           </>
         )}
       </div>,
@@ -55,7 +59,7 @@ export function customToast<T extends string>(
 }
 
 /**
- * Accepts a result returning the inner data or throws an Error.
+ * Accepts a result returning the inner data or returns false that can be checked against.
  * @param result Result of executing a Tauri command.
  * @returns The inner data of the `Ok`
  */

--- a/apps/core/src/routes/connections/route.tsx
+++ b/apps/core/src/routes/connections/route.tsx
@@ -52,7 +52,7 @@ function ConnectionsPage() {
     )
     const connectionEstablishment = unwrapResult(establishConnectionResult)
 
-    if (!connectionEstablishment) return
+    if (connectionEstablishment === false) return
 
     router.navigate({
       to: "/dashboard/land",

--- a/apps/core/src/routes/connections/route.tsx
+++ b/apps/core/src/routes/connections/route.tsx
@@ -24,13 +24,12 @@ export const Route = createFileRoute("/connections")({
   },
   loader: async ({ abortController }) => {
     const commandResult = await commands.getConnections()
-    if (commandResult.status === "error") {
-      unwrapResult(commandResult)
-      return abortController.abort(
-        `error while getting connections: ${commandResult.error}`
-      )
+    const connections = unwrapResult(commandResult)
+    if (!connections) {
+      return abortController.abort(`error while getting connections`)
     }
-    return commandResult.data
+
+    return connections
   },
   staleTime: 0,
   component: ConnectionsPage
@@ -45,7 +44,7 @@ function ConnectionsPage() {
       await commands.getConnectionDetails(connectionId)
     const connectionDetails = unwrapResult(connectionDetailsResult)
 
-    if (connectionDetails === false) return
+    if (!connectionDetails) return
 
     const establishConnectionResult = await commands.establishConnection(
       connectionDetails.connString,
@@ -53,7 +52,7 @@ function ConnectionsPage() {
     )
     const connectionEstablishment = unwrapResult(establishConnectionResult)
 
-    if (connectionEstablishment === false) return
+    if (!connectionEstablishment) return
 
     router.navigate({
       to: "/dashboard/land",

--- a/apps/core/src/routes/dashboard/_layout/$tableName/-components/columns.tsx
+++ b/apps/core/src/routes/dashboard/_layout/$tableName/-components/columns.tsx
@@ -12,6 +12,8 @@ export const generateColumnsDefs = async (
 ) => {
   const columnsResult = await commands.getColumnsProps(tableName)
   const columns = unwrapResult(columnsResult)
+  if (!columns) return
+
   const columnsDefinitions = columns.map(
     ({ columnName, isPK, hasFkRelations }) => {
       const columnDefinition: ColumnDef<ColumnProps> = {

--- a/apps/core/src/settings/manager.ts
+++ b/apps/core/src/settings/manager.ts
@@ -13,6 +13,7 @@ export class SettingsManager {
   constructor() {
     commands.loadSettingsFile().then((result) => {
       const settings = unwrapResult(result)
+      if (!settings) return
       this.settings = settings
     })
   }

--- a/apps/core/src/state/tableState.ts
+++ b/apps/core/src/state/tableState.ts
@@ -10,6 +10,6 @@ export type TableState = {
 export const useTableState = create<TableState>((set) => ({
   tableName: "",
   pkColumn: undefined,
-  updateTableName: (tableName) => set(() => ({ tableName: tableName })),
-  updatePkColumn: (pkColumn) => set(() => ({ pkColumn: pkColumn }))
+  updateTableName: (tableName) => set(() => ({ tableName })),
+  updatePkColumn: (pkColumn) => set(() => ({ pkColumn }))
 }))

--- a/crates/handlers/src/handler.rs
+++ b/crates/handlers/src/handler.rs
@@ -6,6 +6,7 @@ use std::fmt::Debug;
 use tx_lib::{
     decode::{self, decode_raw_rows},
     types::{ColumnProps, FKRows, PaginatedRows},
+    Result,
 };
 
 /// **Handler** must be implemented by any logic handling service, which is
@@ -15,22 +16,19 @@ pub trait Handler: TableHandler + RowHandler + Send + Debug + Sync {}
 #[async_trait]
 /// Every handler must provide it's own implementation of this.
 pub trait TableHandler {
-    async fn get_tables(&self, pool: &AnyPool) -> Result<Vec<AnyRow>, String>;
+    async fn get_tables(&self, pool: &AnyPool) -> Result<Vec<AnyRow>>;
     async fn get_columns_props(
         &self,
         pool: &AnyPool,
         table_name: String,
-    ) -> Result<Vec<ColumnProps>, String>;
+    ) -> Result<Vec<ColumnProps>>;
 
     async fn execute_raw_query(
         &self,
         pool: &AnyPool,
         query: String,
-    ) -> Result<Vec<Map<String, JsonValue>>, String> {
-        let res = sqlx::query(&query)
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
+    ) -> Result<Vec<Map<String, JsonValue>>> {
+        let res = sqlx::query(&query).fetch_all(pool).await?;
         let decoded = decode_raw_rows(res).unwrap();
         Ok(decoded)
     }
@@ -45,7 +43,7 @@ pub trait RowHandler {
         table_name: String,
         page_index: u16,
         page_size: i32,
-    ) -> Result<PaginatedRows, String> {
+    ) -> Result<PaginatedRows> {
         let rows = sqlx::query(
             format!(
                 "SELECT * FROM {} limit {} offset {};",
@@ -56,14 +54,12 @@ pub trait RowHandler {
             .as_str(),
         )
         .fetch_all(pool)
-        .await
-        .unwrap();
+        .await?;
 
         let page_count_result =
             sqlx::query(format!("SELECT COUNT(*) from {}", table_name).as_str())
                 .fetch_one(pool)
-                .await
-                .map_err(|e| e.to_string())?;
+                .await?;
         let page_count = page_count_result.try_get::<i64, usize>(0).unwrap() as i32 / page_size;
 
         let paginated_rows = PaginatedRows::new(decode::decode_raw_rows(rows)?, page_count);
@@ -77,12 +73,9 @@ pub trait RowHandler {
         pk_col_name: String,
         table_name: String,
         params: String,
-    ) -> Result<String, String> {
+    ) -> Result<String> {
         let query_str = format!("DELETE FROM {table_name} WHERE {pk_col_name} in ({params});");
-        let result = sqlx::query(&query_str)
-            .execute(pool)
-            .await
-            .map_err(|e| "Failed to delete rows".to_string())?;
+        let result = sqlx::query(&query_str).execute(pool).await?;
 
         let mut message = String::from("Successfully deleted ");
         if result.rows_affected() == 1 {
@@ -98,12 +91,11 @@ pub trait RowHandler {
         table_name: String,
         columns: String,
         values: String,
-    ) -> Result<String, String> {
+    ) -> Result<String> {
         let res =
             sqlx::query(format!("INSERT INTO {table_name} ({columns}) VALUES({values})").as_str())
                 .execute(pool)
-                .await
-                .map_err(|err| err.to_string())?;
+                .await?;
         Ok(format!("Successfully created {} row", res.rows_affected()))
     }
     async fn update_row(
@@ -113,7 +105,7 @@ pub trait RowHandler {
         set_condition: String,
         pk_col_name: String,
         pk_col_value: JsonValue,
-    ) -> Result<String, String> {
+    ) -> Result<String> {
         let _ = sqlx::query(
             format!(
                 "UPDATE {table_name} SET {set_condition} WHERE {pk_col_name}={}",
@@ -122,8 +114,7 @@ pub trait RowHandler {
             .as_str(),
         )
         .execute(pool)
-        .await
-        .map_err(|_| "Failed to update row".to_string())?;
+        .await?;
         Ok(String::from("Successfully updated row"))
     }
 
@@ -133,5 +124,5 @@ pub trait RowHandler {
         table_name: String,
         column_name: String,
         cell_value: JsonValue,
-    ) -> Result<Vec<FKRows>, String>;
+    ) -> Result<Vec<FKRows>>;
 }

--- a/crates/handlers/src/handler.rs
+++ b/crates/handlers/src/handler.rs
@@ -82,7 +82,7 @@ pub trait RowHandler {
         let result = sqlx::query(&query_str)
             .execute(pool)
             .await
-            .map_err(|_| "Failed to delete rows".to_string())?;
+            .map_err(|e| "Failed to delete rows".to_string())?;
 
         let mut message = String::from("Successfully deleted ");
         if result.rows_affected() == 1 {

--- a/crates/handlers/src/lib.rs
+++ b/crates/handlers/src/lib.rs
@@ -1,10 +1,11 @@
 //! # TableX Handlers
-//! 
+//!
 //! This crate contains the logic for interacting with the database ( i.e performing queries ) for `sqlite`, `postgres`,
 //! and `mysql`..
 
 use sqlx::{any::AnyPoolOptions, AnyPool};
 use std::time::Duration;
+use tx_lib::{Result, TxError};
 
 mod handler;
 mod mysql;
@@ -16,13 +17,13 @@ pub use mysql::MySQLHandler;
 pub use postgres::PostgresHandler;
 pub use sqlite::SQLiteHandler;
 
-pub async fn establish_connection(conn_string: &str) -> Result<AnyPool, String> {
+pub async fn establish_connection(conn_string: &str) -> Result<AnyPool> {
     let pool = AnyPoolOptions::new()
         .acquire_timeout(Duration::from_secs(5))
         .test_before_acquire(true)
         .connect(conn_string)
         .await
-        .map_err(|_| "Couldn't establish connection to db".to_string())?;
+        .map_err(|_| TxError::ConnectionError)?;
 
     Ok(pool)
 }

--- a/crates/keybindings/src/fs.rs
+++ b/crates/keybindings/src/fs.rs
@@ -1,13 +1,16 @@
 use crate::default::get_default_keybindings;
 use std::path::PathBuf;
 use tauri::{Manager, Runtime};
-use tx_lib::fs::{create_json_file_recursively, write_into_json};
+use tx_lib::{
+    fs::{create_json_file_recursively, write_into_json},
+    TxError,
+};
 
 pub const KEYBINDINGS_FILE_NAME: &str = "keybindings.json";
 
 /// make sure that `keybindings.json` file exist and if not will create it
 /// with the default keybindings.
-pub fn ensure_keybindings_file_exist(path: &PathBuf) -> Result<(), String> {
+pub fn ensure_keybindings_file_exist(path: &PathBuf) -> Result<(), TxError> {
     if path.exists() {
         return Ok(());
     }
@@ -19,11 +22,11 @@ pub fn ensure_keybindings_file_exist(path: &PathBuf) -> Result<(), String> {
 /// Get the file path to `keybindings.json`.
 ///
 /// **Varies by platform**.
-pub fn get_keybindings_file_path<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<PathBuf, String> {
-    let mut config_dir = app
-        .path()
-        .app_config_dir()
-        .map_err(|_| "Couldn't read config dir path".to_string())?;
+pub fn get_keybindings_file_path<R: Runtime>(
+    app: &tauri::AppHandle<R>,
+) -> Result<PathBuf, TxError> {
+    let mut config_dir = app.path().app_config_dir()?;
+    // .map_err(|_| "Couldn't read config dir path".to_string())?;
     config_dir.push(KEYBINDINGS_FILE_NAME);
     Ok(config_dir)
 }

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -12,7 +12,9 @@ edition.workspace = true
 serde_json = { workspace = true }
 serde = { workspace = true }
 sqlx = { workspace = true }
+tauri = { workspace = true }
 async-trait = { workspace = true }
 specta = { workspace = true }
 tauri-specta = { workspace = true }
 chrono = "0.4.38"
+thiserror = "1.0.63"

--- a/crates/lib/src/decode.rs
+++ b/crates/lib/src/decode.rs
@@ -1,3 +1,4 @@
+use crate::Result;
 use chrono::{NaiveDate, NaiveDateTime, NaiveTime};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
@@ -28,7 +29,7 @@ pub enum DataType {
 
 /// Utility to decode *most* of db types into serializable rust types.
 /// this code was taken from [here] (https://github.com/tauri-apps/tauri-plugin-sql/blob/v1/src/decode)
-pub fn to_json(v: AnyValueRef) -> Result<JsonValue, String> {
+pub fn to_json(v: AnyValueRef) -> Result<JsonValue> {
     if v.is_null() {
         return Ok(JsonValue::Null);
     }
@@ -130,7 +131,7 @@ pub fn to_json(v: AnyValueRef) -> Result<JsonValue, String> {
             }
         }
         "NULL" | "VOID" => JsonValue::Null,
-        _ => return Err("Unsupported Data type".to_string()),
+        _ => return Err(crate::TxError::UnsupportedDataType),
     };
 
     Ok(res)
@@ -182,7 +183,7 @@ pub fn to_data_type(v: AnyValueRef) -> DataType {
 /// Transform/Decode a `Vec<AnyRow>` into a serializable datastructure.
 ///
 /// Typically used with `SELECT *`.
-pub fn decode_raw_rows(rows: Vec<AnyRow>) -> Result<Vec<JsonMap<String, JsonValue>>, String> {
+pub fn decode_raw_rows(rows: Vec<AnyRow>) -> Result<Vec<JsonMap<String, JsonValue>>> {
     let mut result = Vec::new();
 
     for row in rows {

--- a/crates/lib/src/decode.rs
+++ b/crates/lib/src/decode.rs
@@ -131,7 +131,7 @@ pub fn to_json(v: AnyValueRef) -> Result<JsonValue> {
             }
         }
         "NULL" | "VOID" => JsonValue::Null,
-        _ => return Err(crate::TxError::UnsupportedDataType),
+        other => return Err(crate::TxError::UnsupportedDataType(other.to_string())),
     };
 
     Ok(res)

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -9,32 +9,48 @@ use specta::{
 use thiserror::Error;
 
 #[derive(Debug, Error)]
+/// Global error for all TableX operations.
+///
+/// **Note** that [`serde::Serialize`] is manually implemented for this enum, so
+/// the output data might be different from what you expected.
 pub enum TxError {
     #[error(transparent)]
+    /// Represents all sqlx related errors.
     Database(#[from] sqlx::Error),
 
     #[error(transparent)]
+    /// Represent all filesystem related errors.
     Io(#[from] std::io::Error),
 
     #[error(transparent)]
+    /// Represents tauri runtime's errors.
     TauriError(#[from] tauri::Error),
 
     #[error(transparent)]
+    /// Represents serde's serialization/deserialization errors.
     SerdeError(#[from] serde_json::Error),
 
     #[error("Unsupported data type")]
+    /// Represents errors when trying to decode an unsupported
+    /// datatype to a rust datatype.
     UnsupportedDataType,
 
     #[error("Couldn't connect to DB")]
+    /// Represents database connection errors.
     ConnectionError,
 
     #[error("DB not responding to Pings")]
+    /// Represents database ping errors.
     PingError,
 
     #[error("Invalid connection string format")]
+    /// Represents malformed connection string error
+    /// received from the cli.
     InvalidConnectionString,
 
     #[error("Unsupported driver {0}")]
+    /// For when receiving an unsupported database driver
+    /// from the cli.
     UnsupportedDriver(String),
 }
 

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -30,10 +30,10 @@ pub enum TxError {
     /// Represents serde's serialization/deserialization errors.
     SerdeError(#[from] serde_json::Error),
 
-    #[error("Unsupported data type")]
+    #[error("Unsupported data type {0}")]
     /// Represents errors when trying to decode an unsupported
     /// datatype to a rust datatype.
-    UnsupportedDataType,
+    UnsupportedDataType(String),
 
     #[error("Couldn't connect to DB")]
     /// Represents database connection errors.
@@ -163,7 +163,7 @@ impl Serialize for TxError {
                 message: "Serde serialization error".to_string(),
                 details: error_message,
             },
-            Self::UnsupportedDataType => TxErrorKind::UnsupportedDataType {
+            Self::UnsupportedDataType(_) => TxErrorKind::UnsupportedDataType {
                 message: "Unsupported data type".to_string(),
                 details: error_message,
             },

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -25,6 +25,18 @@ pub enum TxError {
 
     #[error("Unsupported data type")]
     UnsupportedDataType,
+
+    #[error("Couldn't connect to DB")]
+    ConnectionError,
+
+    #[error("DB not responding to Pings")]
+    PingError,
+
+    #[error("Invalid connection string format")]
+    InvalidConnectionString,
+
+    #[error("Unsupported driver {0}")]
+    UnsupportedDriver(String),
 }
 
 impl specta::NamedType for TxError {
@@ -141,6 +153,10 @@ enum TxErrorKind {
     TauriError { message: String, details: String },
     SerdeError { message: String, details: String },
     UnsupportedDataType { message: String, details: String },
+    ConnectionError { message: String },
+    PingError { message: String },
+    InvalidConnectionString { message: String },
+    UnsupportedDriver { message: String },
 }
 
 impl Serialize for TxError {
@@ -169,6 +185,18 @@ impl Serialize for TxError {
             Self::UnsupportedDataType => TxErrorKind::UnsupportedDataType {
                 message: "Unsupported data type".to_string(),
                 details: error_message,
+            },
+            Self::ConnectionError => TxErrorKind::ConnectionError {
+                message: error_message,
+            },
+            Self::PingError => TxErrorKind::PingError {
+                message: error_message,
+            },
+            Self::InvalidConnectionString => TxErrorKind::InvalidConnectionString {
+                message: error_message,
+            },
+            Self::UnsupportedDriver(_) => TxErrorKind::UnsupportedDriver {
+                message: error_message,
             },
         };
         error_kind.serialize(serializer)

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -1,9 +1,8 @@
 use serde::Serialize;
 use specta::{
-    datatype::{reference::reference, EnumRepr, PrimitiveType},
+    datatype::{reference::reference, PrimitiveType},
     internal::construct::{
-        data_type_reference, enum_variant, enum_variant_unit, field, impl_location,
-        named_data_type, r#enum, r#struct, sid, struct_named,
+        data_type_reference, field, impl_location, named_data_type, r#struct, sid, struct_named,
     },
     DataType, Generics, NamedType, SpectaID,
 };
@@ -74,40 +73,6 @@ impl specta::Type for TxError {
             vec![],
             struct_named(
                 vec![
-                    (
-                        "kind".into(),
-                        field(
-                            false,
-                            false,
-                            None,
-                            "Kind of the error".into(),
-                            Some(DataType::Enum(r#enum(
-                                "TxErrorKind".into(),
-                                sid("TxErrorKind", "tx_error_kind"),
-                                EnumRepr::External,
-                                false,
-                                vec![],
-                                vec![
-                                    (
-                                        "Database".into(),
-                                        enum_variant(false, None, "".into(), enum_variant_unit()),
-                                    ),
-                                    (
-                                        "Io".into(),
-                                        enum_variant(false, None, "".into(), enum_variant_unit()),
-                                    ),
-                                    (
-                                        "TauriError".into(),
-                                        enum_variant(false, None, "".into(), enum_variant_unit()),
-                                    ),
-                                    (
-                                        "SerdeError".into(),
-                                        enum_variant(false, None, "".into(), enum_variant_unit()),
-                                    ),
-                                ],
-                            ))),
-                        ),
-                    ),
                     (
                         "message".into(),
                         field(

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -1,0 +1,53 @@
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum TxError {
+    #[error(transparent)]
+    Database(#[from] sqlx::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    #[error(transparent)]
+    TauriError(#[from] tauri::Error),
+}
+
+impl specta::Type for TxError {
+    fn inline(_: &mut specta::TypeMap, _: specta::Generics) -> specta::datatype::DataType {
+        specta::datatype::DataType::Primitive(specta::datatype::PrimitiveType::String)
+    }
+}
+
+#[derive(Serialize)]
+#[serde(tag = "kind")]
+#[serde(rename_all = "camelCase")]
+enum TxErrorKind {
+    Database { message: String, details: String },
+    Io { message: String, details: String },
+    TauriError { message: String, details: String },
+}
+
+impl Serialize for TxError {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let error_message = self.to_string();
+        let error_kind = match self {
+            Self::Database(_) => TxErrorKind::Database {
+                message: "Error from database".to_string(),
+                details: error_message,
+            },
+            Self::Io(_) => TxErrorKind::Io {
+                message: "Filesystem IO error".to_string(),
+                details: error_message,
+            },
+            Self::TauriError(_) => TxErrorKind::TauriError {
+                message: "Tauri runtime error".to_string(),
+                details: error_message,
+            },
+        };
+        error_kind.serialize(serializer)
+    }
+}

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -22,6 +22,9 @@ pub enum TxError {
 
     #[error(transparent)]
     SerdeError(#[from] serde_json::Error),
+
+    #[error("Unsupported data type")]
+    UnsupportedDataType,
 }
 
 impl specta::NamedType for TxError {
@@ -137,6 +140,7 @@ enum TxErrorKind {
     Io { message: String, details: String },
     TauriError { message: String, details: String },
     SerdeError { message: String, details: String },
+    UnsupportedDataType { message: String, details: String },
 }
 
 impl Serialize for TxError {
@@ -160,6 +164,10 @@ impl Serialize for TxError {
             },
             Self::SerdeError(_) => TxErrorKind::SerdeError {
                 message: "Serde serialization error".to_string(),
+                details: error_message,
+            },
+            Self::UnsupportedDataType => TxErrorKind::UnsupportedDataType {
+                message: "Unsupported data type".to_string(),
                 details: error_message,
             },
         };

--- a/crates/lib/src/fs.rs
+++ b/crates/lib/src/fs.rs
@@ -4,20 +4,17 @@ use std::fs::{File, OpenOptions};
 use std::io::{BufReader, BufWriter, Seek, SeekFrom, Write};
 use std::path::PathBuf;
 
+use crate::TxError;
+
 /// Write into _any_ json file (e.g `connections.json`, `keybindings.json`).
-pub fn write_into_json<S>(path: &PathBuf, contents: S) -> Result<(), String>
+pub fn write_into_json<S>(path: &PathBuf, contents: S) -> Result<(), TxError>
 where
     S: Serialize,
 {
-    let file = OpenOptions::new()
-        .write(true)
-        .truncate(true)
-        .open(path)
-        .map_err(|e| e.to_string())?;
+    let file = OpenOptions::new().write(true).truncate(true).open(path)?;
     let mut writer = BufWriter::new(file);
 
-    serde_json::to_writer_pretty(&mut writer, &contents)
-        .map_err(|_| "Failed to write connection record".to_string())?;
+    serde_json::to_writer_pretty(&mut writer, &contents)?;
     writer.flush().unwrap();
     Ok(())
 }
@@ -25,7 +22,7 @@ where
 /// Read from _any_ json file (e.g `connections.json`, `keybindings.json`).
 ///
 /// `D` represents the type to which the contents of the file will be deserialized into.
-pub fn read_from_json<D>(path: &PathBuf) -> Result<D, String>
+pub fn read_from_json<D>(path: &PathBuf) -> Result<D, TxError>
 where
     D: DeserializeOwned,
 {
@@ -33,7 +30,7 @@ where
 
     let _ = file.seek(SeekFrom::Start(0));
     let reader = BufReader::new(file);
-    let content: D = serde_json::from_reader(reader).map_err(|e| e.to_string())?;
+    let content: D = serde_json::from_reader(reader)?;
     Ok(content)
 }
 
@@ -41,23 +38,17 @@ where
 /// Creates an empty json file with all parent directories recursively if it doesn't exist and
 /// write to it and empty object ( `{}` ),
 /// otherwise opens the file and returns it.
-pub fn create_json_file_recursively(path: &PathBuf) -> Result<File, String> {
-    let file_name = path.file_name().unwrap().to_str().unwrap();
+pub fn create_json_file_recursively(path: &PathBuf) -> Result<File, TxError> {
     if path.exists() {
-        let file = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path)
-            .map_err(|_| format!("Couldn't open {file_name}"))?;
+        let file = OpenOptions::new().read(true).write(true).open(path)?;
         return Ok(file);
     }
     let parent = path.parent().unwrap();
     if !parent.exists() {
-        std::fs::create_dir_all(parent)
-            .map_err(|_| "Couldn't create config directory for TableX".to_string())?;
+        std::fs::create_dir_all(parent)?;
     }
-    let mut file = File::create_new(path).map_err(|_| format!("Failed to create {file_name}"))?;
+    let mut file = File::create_new(path)?;
 
-    write!(file, "{{}}").map_err(|_| format!("Couldn't write initial content into {file_name}"))?;
+    write!(file, "{{}}")?;
     Ok(file)
 }

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -12,3 +12,4 @@ pub mod fs;
 pub mod types;
 
 pub use error::TxError;
+pub use types::Result;

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -6,6 +6,9 @@
 //! Other crates can depend on this crate, but this crate *Mustn't* depend on others.
 
 pub mod decode;
+mod error;
 pub mod events;
 pub mod fs;
 pub mod types;
+
+pub use error::TxError;

--- a/crates/lib/src/types.rs
+++ b/crates/lib/src/types.rs
@@ -1,10 +1,15 @@
 use std::collections::HashMap;
 
-use crate::decode::{self, DataType};
+use crate::{
+    decode::{self, DataType},
+    TxError,
+};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map as JsonMap, Value as JsonValue};
 use specta::Type;
 use sqlx::{any::AnyRow, Error, FromRow, Row};
+
+pub type Result<T> = std::result::Result<T, TxError>;
 
 #[derive(Serialize, Deserialize, Debug, Default, Clone, Type)]
 #[serde(rename_all = "lowercase")]
@@ -56,7 +61,7 @@ pub struct ColumnProps {
     pub has_fk_relations: bool,
 }
 impl<'r> FromRow<'r, AnyRow> for ColumnProps {
-    fn from_row(row: &'r AnyRow) -> Result<Self, Error> {
+    fn from_row(row: &'r AnyRow) -> std::result::Result<Self, Error> {
         let column_name: String = row.try_get("column_name")?;
         let data_type: DataType = decode::to_data_type(row.try_get_raw("data_type")?);
         let is_nullable = match row.try_get::<i16, &str>("is_nullable") {

--- a/crates/settings/src/fs.rs
+++ b/crates/settings/src/fs.rs
@@ -1,7 +1,10 @@
 // use crate::default::get_default_keybindings;
 use std::path::PathBuf;
 use tauri::{Manager, Runtime};
-use tx_lib::fs::{create_json_file_recursively, write_into_json};
+use tx_lib::{
+    fs::{create_json_file_recursively, write_into_json},
+    TxError,
+};
 
 use crate::Settings;
 
@@ -9,7 +12,7 @@ pub const SETTINGS_FILE_NAME: &str = "settings.json";
 
 /// make sure that `settings.json` file exist and if not will create it
 /// with the default settings.
-pub fn ensure_settings_file_exist(path: &PathBuf) -> Result<(), String> {
+pub fn ensure_settings_file_exist(path: &PathBuf) -> Result<(), TxError> {
     if path.exists() {
         return Ok(());
     }
@@ -21,11 +24,8 @@ pub fn ensure_settings_file_exist(path: &PathBuf) -> Result<(), String> {
 /// Get the file path to `settings.json`.
 ///
 /// **Varies by platform**.
-pub fn get_settings_file_path<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<PathBuf, String> {
-    let mut config_dir = app
-        .path()
-        .app_config_dir()
-        .map_err(|_| "Couldn't read config dir path".to_string())?;
+pub fn get_settings_file_path<R: Runtime>(app: &tauri::AppHandle<R>) -> Result<PathBuf, TxError> {
+    let mut config_dir = app.path().app_config_dir()?;
     config_dir.push(SETTINGS_FILE_NAME);
     Ok(config_dir)
 }


### PR DESCRIPTION
### What's changed
A universal error interface is created between the frontend and the backend, allowing for cleaner error-handling logic in the backend, and more verbose errors in the frontend.
The frontend now displayed shorthand message errors in a toast with a `more` button that opens a dialog with the detailed error received from the backend.

### Extra dependencies
[thiserror](https://docs.rs/thiserror/latest/thiserror/)

### Closed issues
closes #84 