### PR TITLE
fix: correctly calculate page number in table pagination 🐛

### DIFF
--- a/apps/core/src-tauri/src/commands/row.rs
+++ b/apps/core/src-tauri/src/commands/row.rs
@@ -16,7 +16,7 @@ pub async fn get_paginated_rows(
     state: State<'_, Mutex<SharedState>>,
     table_name: String,
     page_index: u16,
-    page_size: i32,
+    page_size: u32,
 ) -> Result<PaginatedRows> {
     let state = state.lock().await;
     let pool = &state.pool;

--- a/crates/lib/src/types.rs
+++ b/crates/lib/src/types.rs
@@ -36,11 +36,11 @@ pub type ConnectionsFileSchema = HashMap<String, ConnConfig>;
 #[serde(rename_all = "camelCase")]
 pub struct PaginatedRows {
     data: Vec<JsonMap<String, JsonValue>>,
-    page_count: i32,
+    page_count: u32,
 }
 
 impl PaginatedRows {
-    pub fn new(data: Vec<JsonMap<String, JsonValue>>, page_count: i32) -> Self {
+    pub fn new(data: Vec<JsonMap<String, JsonValue>>, page_count: u32) -> Self {
         PaginatedRows { data, page_count }
     }
 }


### PR DESCRIPTION
### Bug description
Previously, there was a missing page ( the last page ) in table pagination, because during calculating the page count, I used a naive division instead of `div_ceil`ing it.