### PR TITLE
refactor: shared table schema context + better row deletions

### DIFF
--- a/apps/desktop/src/components/custom/tooltip-button.tsx
+++ b/apps/desktop/src/components/custom/tooltip-button.tsx
@@ -19,7 +19,7 @@ export const TooltipButton = ({
   return (
     <TooltipProvider>
       <Tooltip>
-        <TooltipTrigger>
+        <TooltipTrigger asChild>
           <Button {...props}>{children}</Button>
         </TooltipTrigger>
         <TooltipContent>{tooltipContent}</TooltipContent>

--- a/apps/desktop/src/features/table-view/columns.tsx
+++ b/apps/desktop/src/features/table-view/columns.tsx
@@ -172,10 +172,10 @@ const appendCheckboxColumn = (columns: ColumnDef<ColumnInfo>[]) => {
   })
 }
 
-export const getZodSchemaFromCols = (table: TableInfo) => {
+export const getZodSchemaFromCols = (tableSchema: TableInfo) => {
   const schemaObject: z.ZodRawShape = {}
 
-  table.columns.forEach((colProps) => {
+  tableSchema.columns.forEach((colProps) => {
     let validationRule: z.ZodTypeAny
 
     switch (colProps.type) {

--- a/apps/desktop/src/features/table-view/components/create-row-sheet.tsx
+++ b/apps/desktop/src/features/table-view/components/create-row-sheet.tsx
@@ -45,9 +45,9 @@ export const AddRowSheet = () => {
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger>
         <TooltipButton
-          size={"sm"}
+          size={"icon"}
           tooltipContent="Add Row"
-          className="h-8 w-8 p-0"
+          className="h-8 w-8"
         >
           <PlusCircle className="size-4" />
         </TooltipButton>

--- a/apps/desktop/src/features/table-view/components/create-row-sheet.tsx
+++ b/apps/desktop/src/features/table-view/components/create-row-sheet.tsx
@@ -21,22 +21,17 @@ import {
 } from "@/components/ui/form"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { getZodSchemaFromCols } from "@/features/table-view/columns"
-import { discoverDBSchemaOptions } from "@/features/table-view/queries"
 import { zodResolver } from "@hookform/resolvers/zod"
-import { useSuspenseQueries } from "@tanstack/react-query"
 import { AlertCircle, PlusCircle } from "lucide-react"
-import { Dispatch, SetStateAction, useState } from "react"
+import { Dispatch, SetStateAction, useMemo, useState } from "react"
 import { useForm } from "react-hook-form"
 import { useHotkeys } from "react-hotkeys-hook"
 import { toast } from "sonner"
 import { z } from "zod"
+import { useTableSchema } from "../context"
 import DynamicFormInput from "./dynamic-input"
 
-type AddRowSheetProps = {
-  tableName: string
-}
-
-export const AddRowSheet = ({ tableName }: AddRowSheetProps) => {
+export const AddRowSheet = () => {
   const [open, setOpen] = useState(false)
 
   useHotkeys("n", () => setOpen(true), {
@@ -65,7 +60,7 @@ export const AddRowSheet = ({ tableName }: AddRowSheetProps) => {
               Click Save to submit your changes.
             </SheetDescription>
           </SheetHeader>
-          <AddRowForm tableName={tableName} setOpen={setOpen} />
+          <AddRowForm setOpen={setOpen} />
         </ScrollArea>
       </SheetContent>
     </Sheet>
@@ -73,24 +68,15 @@ export const AddRowSheet = ({ tableName }: AddRowSheetProps) => {
 }
 
 const AddRowForm = ({
-  tableName,
   setOpen
 }: {
-  tableName: string
   setOpen: Dispatch<SetStateAction<boolean>>
 }) => {
-  const {
-    "0": { data: tableSchema },
-    "1": { data: zodSchema }
-  } = useSuspenseQueries({
-    queries: [
-      discoverDBSchemaOptions(tableName),
-      {
-        ...discoverDBSchemaOptions(tableName),
-        select: getZodSchemaFromCols
-      }
-    ]
-  })
+  const tableSchema = useTableSchema()
+  const zodSchema = useMemo(
+    () => getZodSchemaFromCols(tableSchema),
+    [tableSchema]
+  )
   const form = useForm<z.infer<NonNullable<typeof zodSchema>>>({
     resolver: zodResolver(zodSchema)
   })
@@ -109,7 +95,7 @@ const AddRowForm = ({
       })
     }
 
-    toast.promise(commands.createRow(tableName, vals), {
+    toast.promise(commands.createRow(tableSchema.name, vals), {
       loading: "Creating row...",
       success: () => {
         setOpen(false)

--- a/apps/desktop/src/features/table-view/components/delete-row.tsx
+++ b/apps/desktop/src/features/table-view/components/delete-row.tsx
@@ -1,0 +1,57 @@
+import { commands, RowRecord } from "@/bindings"
+import { TooltipButton } from "@/components/custom/tooltip-button"
+import { Table } from "@tanstack/react-table"
+import { Trash2 } from "lucide-react"
+import { useMemo } from "react"
+import { useHotkeys } from "react-hotkeys-hook"
+import { toast } from "sonner"
+import { useTableSchema } from "../context"
+
+export const DeleteRowBtn = ({ table }: { table: Table<any> }) => {
+  const { pkCols, name: tableName } = useTableSchema()
+  const rowsToDelete: RowRecord[][] = useMemo(
+    () =>
+      table.getSelectedRowModel().flatRows.map((r) =>
+        pkCols.map((col) => ({
+          columnName: col.name,
+          value: r.getValue(col.name),
+          columnType: col.type
+        }))
+      ),
+    [table.getSelectedRowModel().flatRows]
+  )
+
+  const handleDeleteRows = () => {
+    if (pkCols.length === 0)
+      return toast.warning("No primary key defined for this table.")
+
+    toast.promise(commands.deleteRows(rowsToDelete, tableName), {
+      success: () => {
+        table.toggleAllRowsSelected(false)
+        return `Successfully deleted ${rowsToDelete.length} row(s).`
+      },
+      error: () => {
+        return "Something went wrong."
+      }
+    })
+  }
+
+  useHotkeys("delete", handleDeleteRows, {
+    ignoreEventWhen: (e) =>
+      e.target instanceof HTMLInputElement ||
+      e.target instanceof HTMLTextAreaElement
+  })
+
+  return (
+    <TooltipButton
+      size={"icon"}
+      variant={"destructive"}
+      className="h-8 w-8"
+      tooltipContent="Delete"
+      onClick={handleDeleteRows}
+      disabled={rowsToDelete.length === 0}
+    >
+      <Trash2 className="size-4" />
+    </TooltipButton>
+  )
+}

--- a/apps/desktop/src/features/table-view/context.ts
+++ b/apps/desktop/src/features/table-view/context.ts
@@ -1,0 +1,15 @@
+import { TableInfo } from "@/bindings"
+import { createContext, useContext } from "react"
+
+export const TableSchemaContext = createContext<TableInfo | null>(null)
+
+export const useTableSchema = () => {
+  const tableSchema = useContext(TableSchemaContext)
+
+  if (!tableSchema)
+    throw new Error(
+      "useTableSchema must be used within TableSchemaContext provider."
+    )
+
+  return { ...tableSchema, pkCols: tableSchema.columns.filter((c) => c.pk) }
+}

--- a/apps/desktop/src/features/table-view/queries.ts
+++ b/apps/desktop/src/features/table-view/queries.ts
@@ -14,16 +14,6 @@ export const getConnectionDetailsQueryOptions = (connectionId: string) =>
     queryFn: async () => await commands.getConnectionDetails(connectionId)
   })
 
-export const discoverDBSchemaOptions = (tableName: string) =>
-  queryOptions({
-    queryKey: [QUERY_KEYS.DB_SCHEMA, tableName],
-    queryFn: async () => {
-      const schema = await commands.discoverDbSchema()
-      return schema.find((t) => t.name === tableName)!
-    },
-    staleTime: 10 * 60 * 1000 // 1 hour
-  })
-
 export const getPaginatedRowsOptions = (data: GetRowsPayload) => {
   return queryOptions({
     queryKey: [QUERY_KEYS.TABLE_ROWS, data.tableName, { ...data }],


### PR DESCRIPTION
This PR introduces the current table schema as a shared context accessible to all components in the table view. It also reorganizes row deletion logic and adds a button for it in the bottom right-hand corner