### PR TITLE
chore(setup): recrusivly create app data dir path for db file if not exists 🔨

### DIFF
--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -92,6 +92,10 @@ impl Storage {
         }
         if !data_dir.exists() {
             std::fs::create_dir_all(&data_dir).expect("Failed to recursively create app data dir");
+            log::info!(
+                "Recursively created app data dir: {}",
+                data_dir.to_string_lossy()
+            );
         }
         data_dir.push(STORAGE_FILE_NAME);
 

--- a/apps/desktop/src-tauri/src/state.rs
+++ b/apps/desktop/src-tauri/src/state.rs
@@ -65,11 +65,7 @@ impl MetaXState {
     }
 }
 
-const STORAGE_FILE_PATH: &str = if cfg!(debug_assertions) {
-    "dev/data.db"
-} else {
-    "data.db"
-};
+const STORAGE_FILE_NAME: &str = "data.db";
 
 pub struct Storage {
     pool: SqlitePool,
@@ -91,7 +87,13 @@ enum Connection {
 impl Storage {
     pub async fn setup<R: Runtime>(app: &tauri::AppHandle<R>) -> Self {
         let mut data_dir = app.path().app_data_dir().unwrap();
-        data_dir.push(STORAGE_FILE_PATH);
+        if cfg!(debug_assertions) {
+            data_dir.push("dev");
+        }
+        if !data_dir.exists() {
+            std::fs::create_dir_all(&data_dir).expect("Failed to recursively create app data dir");
+        }
+        data_dir.push(STORAGE_FILE_NAME);
 
         let pool = SqlitePool::connect_with(
             SqliteConnectOptions::new()

--- a/crates/tx-lib/src/fs.rs
+++ b/crates/tx-lib/src/fs.rs
@@ -50,11 +50,8 @@ pub fn create_json_file_recursively(path: &PathBuf) -> Result<File, TxError> {
         log::info!("Created {} recursively.", parent.to_str().unwrap());
     }
 
-    let mut file = File::create_new(path)?;
+    let file = File::create_new(path)?;
     log::info!("Created {}.", path.to_str().unwrap());
-
-    write!(file, "{{}}")?;
-    log::info!("Wrote initial content to {}.", path.to_str().unwrap());
 
     Ok(file)
 }


### PR DESCRIPTION
This PR fixes an issue where `data.db` wasn't created on startup bc its ancestor path `app_data_dir` didn't exist