### PR TITLE
feat(data-table): implement column resizing

### DIFF
--- a/apps/desktop/src/components/data-table/data-table.tsx
+++ b/apps/desktop/src/components/data-table/data-table.tsx
@@ -3,8 +3,7 @@ import {
   Row,
   type Table as TanstackTable
 } from "@tanstack/react-table"
-import type * as React from "react"
-import { useMemo } from "react"
+import React, { useMemo } from "react"
 
 import {
   Table,
@@ -40,15 +39,16 @@ export function DataTable<TData>({
   }, [table.getState().columnSizingInfo, table.getState().columnSizing])
 
   return (
-    <ScrollArea
-      className={cn("flex h-full w-full min-w-0 flex-1 flex-col", className)}
+    <div
+      className={cn(
+        "flex h-full w-full min-w-0 flex-1 flex-col overflow-x-auto overflow-ellipsis",
+        className
+      )}
     >
       <Table
-        {...{
-          style: {
-            ...columnSizeVars, //Define column sizes on the <table> element
-            width: table.getTotalSize()
-          }
+        style={{
+          ...columnSizeVars,
+          width: table.getTotalSize()
         }}
       >
         <TableHeader>
@@ -65,7 +65,7 @@ export function DataTable<TData>({
                     ...getCommonPinningStyles({ column: header.column }),
                     width: `calc(var(--header-${header.id}-size) * 1px)`
                   }}
-                  className="text-sm font-bold lg:text-base"
+                  className="group relative overflow-hidden truncate whitespace-nowrap text-sm font-bold lg:text-base"
                 >
                   {header.isPlaceholder
                     ? null
@@ -74,14 +74,18 @@ export function DataTable<TData>({
                         header.getContext()
                       )}
                   <div
-                    {...{
-                      onDoubleClick: () => header.column.resetSize(),
-                      onMouseDown: header.getResizeHandler(),
-                      onTouchStart: header.getResizeHandler(),
-                      className: `absolute w-1 cursor-col-resize top-0 right-0 h-full rounded-md select-none touch-none hover:bg-muted ${
-                        header.column.getIsResizing() ? "bg-blue-500" : ""
-                      }`
-                    }}
+                    onDoubleClick={() => header.column.resetSize()}
+                    onMouseDown={header.getResizeHandler()}
+                    onTouchStart={header.getResizeHandler()}
+                    className={cn(
+                      "absolute right-0 top-1/2 h-4/5 w-2 -translate-y-1/2 cursor-col-resize touch-none select-none rounded-sm transition-colors",
+                      header.column.getIsResizing()
+                        ? "bg-primary"
+                        : "group-hover:bg-muted-foreground/30 bg-transparent"
+                    )}
+                    aria-label="Resize column"
+                    role="separator"
+                    data-resizer="true"
                   />
                 </TableHead>
               ))}
@@ -107,9 +111,10 @@ export function DataTable<TData>({
                   <TableCell
                     key={cell.id}
                     style={{
-                      ...getCommonPinningStyles({ column: cell.column })
+                      ...getCommonPinningStyles({ column: cell.column }),
+                      width: `calc(var(--col-${cell.column.id}-size) * 1px)`
                     }}
-                    className="w-1"
+                    className="w-1 overflow-hidden truncate whitespace-nowrap"
                   >
                     {flexRender(cell.column.columnDef.cell, cell.getContext())}
                   </TableCell>
@@ -120,7 +125,7 @@ export function DataTable<TData>({
             <TableRow>
               <TableCell
                 colSpan={table.getAllColumns().length}
-                className="h-24 text-center"
+                className="h-24 truncate text-center"
               >
                 No results.
               </TableCell>
@@ -128,7 +133,6 @@ export function DataTable<TData>({
           )}
         </TableBody>
       </Table>
-      <ScrollBar orientation="horizontal" />
-    </ScrollArea>
+    </div>
   )
 }

--- a/apps/desktop/src/components/ui/table.tsx
+++ b/apps/desktop/src/components/ui/table.tsx
@@ -1,0 +1,135 @@
+import * as React from "react"
+
+import { cn } from "@tablex/lib/utils"
+import { Virtualizer } from "@tanstack/react-virtual"
+
+interface TableProps extends   React.HTMLAttributes<HTMLTableElement>   {
+  virtualizerRef:React.RefObject<HTMLDivElement>
+  virtualizer:Virtualizer<any,any>
+}
+const Table = React.forwardRef<
+  HTMLTableElement,
+  React.HTMLAttributes<HTMLTableElement>
+>(({ className, ...props }, ref) => (
+  <div className="relative overflow-x-auto w-full">
+    <table
+      ref={ref}
+      className={cn("caption-bottom text-sm table-fixed", className)}
+      {...props}
+    />
+  </div>
+))
+Table.displayName = "Table"
+
+const VirtualTable = React.forwardRef<
+  HTMLTableElement,
+  TableProps
+>(({ className,virtualizerRef,virtualizer, ...props }, ref) => (
+  <div className="relative h-full w-full " >
+    <div ref={virtualizerRef} style={{height:`${virtualizer.getTotalSize()}px`}}>
+    <table
+      ref={ref}
+      className={cn("caption-bottom text-sm table-fixed", className)}
+      {...props}
+    />
+    </div>
+  </div>
+))
+VirtualTable.displayName = "VirtualTable"
+
+const TableHeader = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <thead ref={ref} className={cn("[&_tr]:border-b", className)} {...props} />
+))
+TableHeader.displayName = "TableHeader"
+
+const TableBody = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tbody
+    ref={ref}
+    className={cn("[&_tr:last-child]:border-0", className)}
+    {...props}
+  />
+))
+TableBody.displayName = "TableBody"
+
+const TableFooter = React.forwardRef<
+  HTMLTableSectionElement,
+  React.HTMLAttributes<HTMLTableSectionElement>
+>(({ className, ...props }, ref) => (
+  <tfoot
+    ref={ref}
+    className={cn(
+      "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableFooter.displayName = "TableFooter"
+
+const TableRow = React.forwardRef<
+  HTMLTableRowElement,
+  React.HTMLAttributes<HTMLTableRowElement>
+>(({ className, ...props }, ref) => (
+  <tr
+    ref={ref}
+    className={cn("data-[state=selected]:bg-muted border-b ", className)}
+    {...props}
+  />
+))
+TableRow.displayName = "TableRow"
+
+const TableHead = React.forwardRef<
+  HTMLTableCellElement,
+  React.ThHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <th
+    ref={ref}
+    className={cn(
+      "text-muted-foreground h-12 px-4 text-left align-middle font-medium [&:has([role=checkbox])]:pr-0",
+      className
+    )}
+    {...props}
+  />
+))
+TableHead.displayName = "TableHead"
+
+const TableCell = React.forwardRef<
+  HTMLTableCellElement,
+  React.TdHTMLAttributes<HTMLTableCellElement>
+>(({ className, ...props }, ref) => (
+  <td
+    ref={ref}
+    className={cn("px-4 py-3 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    {...props}
+  />
+))
+TableCell.displayName = "TableCell"
+
+const TableCaption = React.forwardRef<
+  HTMLTableCaptionElement,
+  React.HTMLAttributes<HTMLTableCaptionElement>
+>(({ className, ...props }, ref) => (
+  <caption
+    ref={ref}
+    className={cn("text-muted-foreground mt-4 text-sm", className)}
+    {...props}
+  />
+))
+TableCaption.displayName = "TableCaption"
+
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow, VirtualTable
+}

--- a/apps/desktop/src/features/table-view/columns.tsx
+++ b/apps/desktop/src/features/table-view/columns.tsx
@@ -24,9 +24,41 @@ declare module "@tanstack/react-table" {
 
 export const generateColumnsDefs = (table: TableInfo) => {
   const columnsDefinitions = table.columns.map(({ name, type }) => {
+    const getColumnSize = () => {
+      const typeStr = typeof type === "string" ? type : "custom"
+
+      // Type-based defaults
+      switch (typeStr) {
+        case "boolean":
+          return { size: 80, minSize: 60, maxSize: 120 }
+        case "integer":
+        case "positiveInteger":
+        case "float":
+          return { size: 100, minSize: 70, maxSize: 500 }
+        case "date":
+        case "dateTime":
+          return { size: 180, minSize: 120, maxSize: 250 }
+        case "time":
+          return { size: 180, minSize: 120, maxSize: 250 }
+        case "year":
+          return { size: 180, minSize: 120, maxSize: 250 }
+        case "json":
+        case "text":
+          return { size: 200, minSize: 80, maxSize: 1000 }
+        case "uuid":
+          return { size: 250, minSize: 200, maxSize: 300 }
+        case "binary":
+        case "unSupported":
+          return { size: 120, minSize: 100, maxSize: 1000 }
+        default:
+          return { size: 250, minSize: 80, maxSize: 1000 }
+      }
+    }
+
     const columnDefinition: ColumnDef<ColumnInfo> = {
       accessorKey: name,
       id: name,
+      ...getColumnSize(),
       header: ({ column }) => {
         return <DataTableColumnHeader column={column} title={name} />
       },
@@ -139,6 +171,9 @@ export const generateColumnsDefs = (table: TableInfo) => {
 const appendCheckboxColumn = (columns: ColumnDef<ColumnInfo>[]) => {
   columns.unshift({
     id: "select",
+    size: 50,
+    minSize: 40,
+    maxSize: 60,
     header: ({ table }) => (
       <Checkbox
         checked={

--- a/apps/desktop/src/hooks/use-setup-data-table.ts
+++ b/apps/desktop/src/hooks/use-setup-data-table.ts
@@ -36,6 +36,13 @@ export const useSetupDataTable = <TData, TValue>({
   const table = useReactTable({
     data: (data?.data as TData[]) ?? FALLBACK_DATA,
     columns,
+    defaultColumn: {
+      size: 100,
+      minSize: 20,
+      maxSize: 1000
+    },
+    enableColumnResizing: true,
+    columnResizeMode: "onChange",
     pageCount: data?.pageCount ?? -1,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),

--- a/apps/desktop/src/hooks/use-setup-data-table.ts
+++ b/apps/desktop/src/hooks/use-setup-data-table.ts
@@ -37,8 +37,8 @@ export const useSetupDataTable = <TData, TValue>({
     data: (data?.data as TData[]) ?? FALLBACK_DATA,
     columns,
     defaultColumn: {
-      size: 100,
-      minSize: 20,
+      size: 200,
+      minSize: 40,
       maxSize: 1000
     },
     enableColumnResizing: true,


### PR DESCRIPTION
This adds support for column resizing as mentioned in #96.

Columns also now have more defined defaults based on the data type. This can easily be removed if you would prefer to not have this behaviour!

I tried re-using the existing styles and tried to keep to the current look and feel.

If there is anything that you would like changed or don't agree with, please let me know :)

<img width="486" height="263" alt="image" src="https://github.com/user-attachments/assets/c5b8f177-5497-470a-b97e-e46e281112aa" />
